### PR TITLE
Adopt server-rotated session tokens (contract 1.1.0)

### DIFF
--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -21,6 +21,7 @@ import io.github.xexanos.ratatoskr.network.generated.model.LoginRequest
 import io.github.xexanos.ratatoskr.network.generated.model.SeekRequest
 import io.github.xexanos.ratatoskr.network.generated.model.StartSessionRequest
 import io.github.xexanos.ratatoskr.network.generated.model.Error as GenError
+import io.github.xexanos.ratatoskr.network.generated.model.Session as GenSession
 import io.github.xexanos.ratatoskr.network.persist.TokenAccess
 import com.squareup.moshi.Moshi
 import retrofit2.Response
@@ -72,7 +73,8 @@ class RatatoskrClient internal constructor(
         execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain() }
 
     suspend fun currentSession(): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.getCurrentSession() }.map { it.toDomain() }
+        execute(sessionEndpoint = true) { playbackApi.getCurrentSession() }
+            .adoptingRotatedTokens().map { it.toDomain() }
 
     /**
      * Starts playback. The stored refresh token is handed to the server so its sync loop can
@@ -83,21 +85,52 @@ class RatatoskrClient internal constructor(
         val refreshToken = tokenStore.refreshToken()
         return execute {
             playbackApi.startSession(StartSessionRequest(itemId, speakerId, refreshToken))
-        }.map { it.toDomain() }
+        }.adoptingRotatedTokens().map { it.toDomain() }
     }
 
+    /**
+     * Stops playback. The contract returns 204 normally, or 200 with a final [GenSession]
+     * carrying a still-pending rotated token pair (SPEC section 5); either counts as success.
+     * Any pair in a 200 body is adopted before the session ends, since the server discards its
+     * in-memory tokens on stop and cannot redeliver them.
+     */
     suspend fun stopSession(): ApiResult<Unit> =
-        executeUnit(sessionEndpoint = true) { playbackApi.stopSession() }
+        when (val result = executeNullable(sessionEndpoint = true) { playbackApi.stopSession() }) {
+            is ApiResult.Success -> {
+                result.data?.adoptRotatedTokens()
+                ApiResult.Success(Unit)
+            }
+            is ApiResult.Failure -> result
+        }
 
     suspend fun pause(): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.pauseSession() }.map { it.toDomain() }
+        execute(sessionEndpoint = true) { playbackApi.pauseSession() }
+            .adoptingRotatedTokens().map { it.toDomain() }
 
     suspend fun resume(): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.resumeSession() }.map { it.toDomain() }
+        execute(sessionEndpoint = true) { playbackApi.resumeSession() }
+            .adoptingRotatedTokens().map { it.toDomain() }
 
     suspend fun seek(positionSeconds: Double): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.seekSession(SeekRequest(positionSeconds)) }
-            .map { it.toDomain() }
+            .adoptingRotatedTokens().map { it.toDomain() }
+
+    // --- token adoption -----------------------------------------------------------------
+
+    /**
+     * Adopts a rotated token pair carried on a successful [GenSession] response and passes the
+     * result through unchanged. This is how the app learns the tokens the server rotated during
+     * an active session, since it does not refresh on its own while a session is live
+     * (SPEC section 5).
+     */
+    private suspend fun ApiResult<GenSession>.adoptingRotatedTokens(): ApiResult<GenSession> {
+        (this as? ApiResult.Success)?.data?.adoptRotatedTokens()
+        return this
+    }
+
+    private suspend fun GenSession.adoptRotatedTokens() {
+        rotatedTokens?.let { tokenStore.updateTokens(it.accessToken, it.refreshToken) }
+    }
 
     // --- error handling -----------------------------------------------------------------
 
@@ -120,12 +153,17 @@ class RatatoskrClient internal constructor(
         ApiResult.Failure(mapThrowable(t))
     }
 
-    private suspend fun executeUnit(
+    /**
+     * Like [execute] but tolerates an empty body: a 204 (or any success with no body) becomes
+     * `Success(null)` rather than a failure. Used where the contract allows either a body or an
+     * empty success, e.g. stopSession returning 204 or 200-with-Session.
+     */
+    private suspend fun <T : Any> executeNullable(
         sessionEndpoint: Boolean = false,
-        call: suspend () -> Response<Unit>,
-    ): ApiResult<Unit> = try {
+        call: suspend () -> Response<T>,
+    ): ApiResult<T?> = try {
         val response = call()
-        if (response.isSuccessful) ApiResult.Success(Unit)
+        if (response.isSuccessful) ApiResult.Success(response.body())
         else ApiResult.Failure(mapHttpError(response.code(), response.errorBody()?.string(), sessionEndpoint))
     } catch (t: Throwable) {
         // Never swallow coroutine cancellation: rethrow so structured concurrency can unwind

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -146,4 +146,64 @@ class RatatoskrClientTest {
 
         assertTrue(job.isCancelled)
     }
+
+    @Test
+    fun `a session response with rotatedTokens is adopted`() = runBlocking {
+        server.enqueue(
+            MockResponse().setBody(
+                """{"itemId":"i1","speakerId":"s1","state":"playing","positionSeconds":1.0,
+                   "durationSeconds":10.0,"updatedAt":"2026-07-05T12:00:00Z",
+                   "rotatedTokens":{"accessToken":"a2","refreshToken":"r2"}}""",
+            ),
+        )
+
+        val result = client.currentSession()
+
+        assertTrue(result is ApiResult.Success)
+        assertEquals("a2", tokens.currentAccessTokenBlocking())
+        assertEquals("r2", tokens.refreshToken())
+    }
+
+    @Test
+    fun `a session response without rotatedTokens leaves the stored pair untouched`() = runBlocking {
+        server.enqueue(
+            MockResponse().setBody(
+                """{"itemId":"i1","speakerId":"s1","state":"playing","positionSeconds":1.0,
+                   "durationSeconds":10.0,"updatedAt":"2026-07-05T12:00:00Z"}""",
+            ),
+        )
+
+        client.currentSession()
+
+        assertEquals("a0", tokens.currentAccessTokenBlocking())
+        assertEquals("r0", tokens.refreshToken())
+    }
+
+    @Test
+    fun `stopSession adopts a rotated pair from a 200 body`() = runBlocking {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"itemId":"i1","speakerId":"s1","state":"stopped","positionSeconds":5.0,
+                   "durationSeconds":10.0,"updatedAt":"2026-07-05T12:00:00Z",
+                   "rotatedTokens":{"accessToken":"a3","refreshToken":"r3"}}""",
+            ),
+        )
+
+        val result = client.stopSession()
+
+        assertTrue(result is ApiResult.Success)
+        assertEquals("a3", tokens.currentAccessTokenBlocking())
+        assertEquals("r3", tokens.refreshToken())
+    }
+
+    @Test
+    fun `stopSession succeeds on a 204 and keeps the stored tokens`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        val result = client.stopSession()
+
+        assertTrue(result is ApiResult.Success)
+        assertEquals("a0", tokens.currentAccessTokenBlocking())
+        assertEquals("r0", tokens.refreshToken())
+    }
 }


### PR DESCRIPTION
## What

Wires the client half of the refresh-token rotation handover now that the server contract landed as 1.1.0 (server PR #11).

- **Submodule bump** to the merged server `main` (`95a2552`): the generated client gains the optional `Session.rotatedTokens` pair and `stopSession` now returns 200-with-`Session` in addition to 204.
- **Token adoption** (SPEC section 5): every session-returning call (`currentSession`, `startSession`, `pause`, `resume`, `seek`) adopts a `rotatedTokens` pair into the token store, so the app picks up tokens the server rotated during an active session without refreshing on its own.
- **`stopSession`** handles the new 200-with-`Session` as well as 204, adopting any pending pair from the final body before the session ends (the server discards its in-memory tokens on stop and cannot redeliver them).

The refresh-suppression plumbing this relies on was already in place (`ConnectionManager.setSessionActive` → `TokenRefreshAuthenticator`); this PR makes the adoption actually happen.

## Scope notes

- The domain `Session` model and the mappers are intentionally unchanged — token handling stays in the network layer and the UI never sees `rotatedTokens`.

## Tests

Four new tests in `RatatoskrClientTest` (adoption from a session body, no-op when absent, `stopSession` on both 200-with-pair and 204). Full `core-network` suite: 22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
