### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot configuration.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Gradle dependencies (Kotlin/Android app + all sub-modules).
+  # Dependabot scans build.gradle(.kts) and version catalogs recursively from "/".
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Keep PR noise low: bundle non-major bumps into a single PR, majors stay separate.
+    groups:
+      gradle-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep GitHub Actions workflows up to date (once any land under .github/workflows).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Enables Dependabot version updates for the repository.

## What
- **Gradle** (`/`, weekly): covers the Kotlin/Android app and sub-modules, incl. the version catalog. Minor/patch bumps are grouped into a single PR; majors stay separate.
- **GitHub Actions** (`/`, weekly): takes effect once workflows land under `.github/workflows/`.

## Notes
- Version updates activate once this file is on the default branch (`main`).
- No Gradle build files are committed yet, so Dependabot won't open dependency PRs until the build setup lands — the config is inert until then, which is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)