### PR TITLE
spec: plan R8/shrinking as near-term build hardening

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -185,6 +185,19 @@ screen exposes the server URL, a re-trust/forget action for the certificate, and
   `fdroiddata` repository, not here.
 - Choose a reasonable `minSdk` that covers the encrypted-storage and TLS requirements; the
   agent proposes the exact value.
+- Release shrinking (R8) is near-term build hardening, not a post-v1 nice-to-have: take it
+  up soon — after the integration-test layer below (section 9) — so the debt of shipping
+  unshrunk stops growing. It is currently disabled because the generated API client uses
+  reflective Moshi adapters (`@JsonClass(generateAdapter = false)`); enabling shrinking first
+  needs validated Moshi/Retrofit keep rules, or (better) switching the generator to Moshi
+  codegen adapters so no reflection is kept at all. Sequencing it right after the integration
+  tests is deliberate: that harness drives real responses through the factory's own Moshi over
+  `MockWebServer`, which is exactly what verifies a minified build still deserializes correctly.
+  While it stays off, unused code and resources accumulate unshrunk (e.g. the vectors pulled in
+  with `material-icons-extended`), inflating the F-Droid build size — the longer it waits, the
+  more debt it carries. Until the keep rules are validated against a real minified, on-device
+  run, the release ships unshrunk rather than risk a runtime-only break; the `build.gradle.kts`
+  release block carries the same rationale where it is off.
 
 ## 9. Testing
 


### PR DESCRIPTION
## Summary

Records **R8/release shrinking** in `docs/SPEC.md` (section 8, Distribution constraints) as **near-term build hardening** — not a post-v1 nice-to-have.

R8 is currently disabled because the generated API client uses reflective Moshi adapters — enabling shrinking first needs validated Moshi/Retrofit keep rules, or a switch to the generator's Moshi codegen adapters so no reflection is kept. Until now that rationale only lived in two ephemeral places:
- a comment in `app/build.gradle.kts` ("Tracked as a follow-up" — but tracked nowhere), and
- review finding #14 on #3.

## Why near-term, not deferred

Left off, the debt only grows: unused code and resources accumulate unshrunk — e.g. #4 adds `material-icons-extended`, whose largely-unused vector set now ships in full — inflating the F-Droid build size. The note plans it **right after the integration-test layer (section 9)**: that harness drives real responses through the factory's own Moshi over `MockWebServer`, which is exactly what verifies a minified build still deserializes correctly. So the sequencing is deliberate — the tests come first because they're the safety net for turning R8 on.

The `build.gradle.kts` comment stays as the "why it's off" at the point where it is off; the SPEC carries the "when we take it on".

No code or build behaviour changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)