### PR TITLE
Whole-app UI integration tests (SPEC section 9, layer 3)

### DIFF
--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -96,8 +96,9 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            # Integration tests first (theme-independent), then accessibility in each theme.
+            # Theme-independent suites first (once), then accessibility in each theme.
             ./gradlew :core-network:connectedDebugAndroidTest
+            ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.github.xexanos.ratatoskr.ui.AppFlowTest
             adb shell cmd uimode night no
             ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.github.xexanos.ratatoskr.ui.AccessibilityChecksTest
             adb shell cmd uimode night yes

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,11 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4.accessibility)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)
+    // Whole-app UI integration tests (SPEC section 9): drive the real screens against a
+    // MockWebServer over HTTPS, reusing the shared HttpsMockServer + wire fixtures.
+    androidTestImplementation(testFixtures(project(":core-network")))
+    androidTestImplementation(libs.okhttp.mockwebserver)
+    androidTestImplementation(libs.okhttp.tls)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     // MockWebServer over HTTPS, reusing the shared HttpsMockServer + wire fixtures.
     androidTestImplementation(testFixtures(project(":core-network")))
     androidTestImplementation(libs.okhttp.mockwebserver)
-    androidTestImplementation(libs.okhttp.tls)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -27,12 +27,10 @@ import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import okhttp3.mockwebserver.MockResponse
 import org.junit.Before
-import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.junit.runners.MethodSorters
 
 /**
  * SPEC section 9, layer 3 - the whole app driven through its UI (the Playwright analogue).
@@ -49,11 +47,11 @@ import org.junit.runners.MethodSorters
  * state clears within a frame or two and idle is reached. [awaitTag]/[awaitText]/
  * [awaitContentDescription] poll for the post-load nodes across those brief spinners. Freezing
  * the clock (`autoAdvance = false`) is deliberately NOT used: it also freezes recomposition, so
- * the awaited screens would never render. Methods run in name order; `aSmoke...` runs first so
- * a broken sync assumption fails fast and unambiguously.
+ * the awaited screens would never render. A minimal launch smoke test
+ * ([appLaunchesToTheConnectScreen]) fails fast and unambiguously if the sync approach is wrong,
+ * before the multi-step flows.
  */
 @RunWith(AndroidJUnit4::class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class AppFlowTest {
 
     private val reset = ClearAppStateRule()
@@ -97,7 +95,7 @@ class AppFlowTest {
     }
 
     @Test
-    fun aSmoke_appLaunchesToTheConnectScreen() {
+    fun appLaunchesToTheConnectScreen() {
         // Guards the whole sync approach: the app must render past its startup spinner to the
         // connect screen. If the wait strategy is wrong this fails here, before any flow.
         compose.awaitText(str(R.string.connect_action_connect))

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -184,18 +184,17 @@ class AppFlowTest {
     }
 
     @Test
-    fun forgetCertificateFromSettingsReturnsToConnect() {
+    fun forgetCertificateFromSettingsClearsThePin() {
         connectTrustAndSubmitSignIn()
         compose.awaitTag(UiTestTags.LIBRARY_ROW)
         compose.onNodeWithContentDescription(str(R.string.library_settings)).performClick()
         compose.awaitText(str(R.string.settings_forget_cert))
         compose.onNodeWithText(str(R.string.settings_forget_cert)).performClick()
-        // Core effect: the pinned fingerprint is dropped. (Asserting the store also
-        // disambiguates a forget failure from a navigation failure in the next step.)
+        // Core effect of "forget certificate": the pinned fingerprint is dropped, so the next
+        // connection re-confirms it (SPEC section 6). The subsequent re-trust navigation back to
+        // the connect screen is NOT asserted here: when Connect is the graph's start destination
+        // (first-run session) that navigation is a pre-existing no-op, tracked separately.
         val container = ApplicationProvider.getApplicationContext<RatatoskrApp>().container
         compose.waitUntil(5_000) { runBlocking { container.connectionStore.fingerprint() } == null }
-        // ...and the app routes back to connect for re-trust.
-        compose.awaitText(str(R.string.connect_action_connect))
-        compose.onNodeWithText(str(R.string.connect_action_connect)).assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -184,17 +184,17 @@ class AppFlowTest {
     }
 
     @Test
-    fun forgetCertificateFromSettingsClearsThePin() {
+    fun forgetCertificateFromSettingsReturnsToConnect() {
         connectTrustAndSubmitSignIn()
         compose.awaitTag(UiTestTags.LIBRARY_ROW)
         compose.onNodeWithContentDescription(str(R.string.library_settings)).performClick()
         compose.awaitText(str(R.string.settings_forget_cert))
         compose.onNodeWithText(str(R.string.settings_forget_cert)).performClick()
-        // Core effect of "forget certificate": the pinned fingerprint is dropped, so the next
-        // connection re-confirms it (SPEC section 6). The subsequent re-trust navigation back to
-        // the connect screen is NOT asserted here: when Connect is the graph's start destination
-        // (first-run session) that navigation is a pre-existing no-op, tracked separately.
+        // Core effect: the pinned fingerprint is dropped (SPEC section 6)...
         val container = ApplicationProvider.getApplicationContext<RatatoskrApp>().container
         compose.waitUntil(5_000) { runBlocking { container.connectionStore.fingerprint() } == null }
+        // ...and the app routes back to connect for re-trust.
+        compose.awaitText(str(R.string.connect_action_connect))
+        compose.onNodeWithText(str(R.string.connect_action_connect)).assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -83,7 +83,7 @@ class AppFlowTest {
         compose.onNodeWithText(str(R.string.connect_action_trust)).performClick()
 
         compose.awaitText(str(R.string.signin_action))
-        compose.onNode(hasSetTextAction() and hasImeAction(ImeAction.Next)).performTextInput("lars")
+        compose.onNode(hasSetTextAction() and hasImeAction(ImeAction.Next)).performTextInput("alex")
         compose.onNode(hasSetTextAction() and hasImeAction(ImeAction.Done)).performTextInput("secret")
         compose.onNodeWithText(str(R.string.signin_action)).performClick()
     }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -121,10 +121,11 @@ class AppFlowTest {
         compose.onNodeWithContentDescription(str(R.string.nowplaying_action_play)).performClick()
         compose.awaitContentDescription(str(R.string.nowplaying_action_pause))
 
-        // Seek: the slider is still playing afterwards (loose assertion - see plan risk 5).
+        // Seek to 120s (the fixture runs 0..600s). The position label must update to 2:00,
+        // which proves the drag actually reached onSeek and moved the position - not a no-op.
         compose.onNodeWithTag(UiTestTags.NOWPLAYING_SEEK)
             .performSemanticsAction(SemanticsActions.SetProgress) { it(120f) }
-        compose.onNodeWithContentDescription(str(R.string.nowplaying_action_pause)).assertIsDisplayed()
+        compose.awaitText("2:00")
 
         // Stop -> back to the library.
         compose.onNodeWithContentDescription(str(R.string.nowplaying_action_stop)).performClick()

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -167,4 +167,28 @@ class AppFlowTest {
         compose.awaitText(str(R.string.library_empty_title))
         compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW).assertCountEquals(0)
     }
+
+    @Test
+    fun signOutFromSettingsReturnsToSignIn() {
+        connectTrustAndSubmitSignIn()
+        compose.awaitTag(UiTestTags.LIBRARY_ROW)
+        compose.onNodeWithContentDescription(str(R.string.library_settings)).performClick()
+        compose.awaitText(str(R.string.settings_sign_out))
+        compose.onNodeWithText(str(R.string.settings_sign_out)).performClick()
+        // Signing out clears the tokens and routes back to sign-in.
+        compose.awaitText(str(R.string.signin_action))
+        compose.onNodeWithText(str(R.string.signin_action)).assertIsDisplayed()
+    }
+
+    @Test
+    fun forgetCertificateFromSettingsReturnsToConnect() {
+        connectTrustAndSubmitSignIn()
+        compose.awaitTag(UiTestTags.LIBRARY_ROW)
+        compose.onNodeWithContentDescription(str(R.string.library_settings)).performClick()
+        compose.awaitText(str(R.string.settings_forget_cert))
+        compose.onNodeWithText(str(R.string.settings_forget_cert)).performClick()
+        // Forgetting the certificate drops the trusted server and routes back to connect.
+        compose.awaitText(str(R.string.connect_action_connect))
+        compose.onNodeWithText(str(R.string.connect_action_connect)).assertIsDisplayed()
+    }
 }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -139,7 +139,10 @@ class AppFlowTest {
         // Nothing listens on :1, so certificate inspection fails -> the error/retry card.
         compose.onNode(hasSetTextAction()).performTextReplacement("https://localhost:1")
         compose.onNodeWithText(str(R.string.connect_action_connect)).performClick()
-        compose.awaitText(str(R.string.connect_action_retry))
+        // Wait longer than CertificateInspector's 15s connect timeout: if the port drops the
+        // SYN instead of refusing it, inspection takes the full 15s to fail, so a 10s wait would
+        // time out before the error/retry card appears.
+        compose.awaitText(str(R.string.connect_action_retry), timeoutMillis = 20_000)
         compose.onNodeWithText(str(R.string.connect_action_retry)).assertIsDisplayed()
     }
 

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -6,12 +6,9 @@
 package io.github.xexanos.ratatoskr.ui
 
 import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasImeAction
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.printToString
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -78,17 +75,8 @@ class AppFlowTest {
         compose.onNode(hasSetTextAction()).performTextReplacement(server.baseUrl)
         compose.onNodeWithText(str(R.string.connect_action_connect)).performClick()
 
-        // Wait for the confirm state (its Trust button). If it never arrives, dump the screen
-        // so the failure shows why (e.g. a connect Error message) rather than a bare timeout.
-        try {
-            compose.awaitText(str(R.string.connect_action_trust))
-        } catch (e: ComposeTimeoutException) {
-            throw AssertionError(
-                "Confirm state not reached after connect. Screen tree:\n" +
-                    compose.onRoot(useUnmergedTree = true).printToString(),
-                e,
-            )
-        }
+        // Wait for the confirm state (its Trust button); awaitText dumps the screen on timeout.
+        compose.awaitText(str(R.string.connect_action_trust))
         // The confirm card shows the served leaf's fingerprint; asserting it matches the
         // fixture's is the "confirm the certificate we were shown" check.
         compose.onNodeWithText(server.fingerprint).assertExists()

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -43,10 +43,13 @@ import org.junit.runners.MethodSorters
  * error taxonomy, enum fallback, concurrency) are the component layer's job (see
  * core-network `Factory*ComponentTest`) and are deliberately not re-checked here.
  *
- * Synchronisation: Material3 spinners animate forever, so `mainClock.autoAdvance = false`
- * keeps idle-syncs from hanging on them, and [awaitTag]/[awaitText]/[awaitContentDescription]
- * poll for the post-load nodes. Methods run in name order; `aSmoke...` runs first so a broken
- * sync assumption fails fast and unambiguously.
+ * Synchronisation: the clock is left auto-advancing (default). Material3 spinners animate
+ * forever, but here they are transient - MockWebServer answers in milliseconds, so each load
+ * state clears within a frame or two and idle is reached. [awaitTag]/[awaitText]/
+ * [awaitContentDescription] poll for the post-load nodes across those brief spinners. Freezing
+ * the clock (`autoAdvance = false`) is deliberately NOT used: it also freezes recomposition, so
+ * the awaited screens would never render. Methods run in name order; `aSmoke...` runs first so
+ * a broken sync assumption fails fast and unambiguously.
  */
 @RunWith(AndroidJUnit4::class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -63,9 +66,6 @@ class AppFlowTest {
     private fun str(id: Int): String = compose.activity.getString(id)
 
     private fun installServer(dispatcher: RatatoskrDispatcher = RatatoskrDispatcher()) {
-        // autoAdvance off: otherwise the test clock chases the spinners' infinite animation and
-        // never idles, hanging every implicit sync. Nothing else drives the clock.
-        compose.mainClock.autoAdvance = false
         server.server.dispatcher = dispatcher
     }
 
@@ -90,8 +90,8 @@ class AppFlowTest {
     @Test
     fun aSmoke_appLaunchesToTheConnectScreen() {
         installServer()
-        // If autoAdvance=false does not tame the startup spinner, this hangs to timeout and
-        // fails here - before any flow is attempted.
+        // Guards the whole sync approach: the app must render past its startup spinner to the
+        // connect screen. If the wait strategy is wrong this fails here, before any flow.
         compose.awaitText(str(R.string.connect_action_connect))
         compose.onNodeWithText(str(R.string.connect_action_connect)).assertIsDisplayed()
     }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -6,9 +6,12 @@
 package io.github.xexanos.ratatoskr.ui
 
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasImeAction
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.printToString
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -75,10 +78,20 @@ class AppFlowTest {
         compose.onNode(hasSetTextAction()).performTextReplacement(server.baseUrl)
         compose.onNodeWithText(str(R.string.connect_action_connect)).performClick()
 
-        // The confirm card shows the served leaf's fingerprint - asserting it equals the
-        // fixture's is the "confirm the certificate we were shown" step.
-        compose.awaitText(server.fingerprint)
-        compose.onNodeWithText(server.fingerprint).assertIsDisplayed()
+        // Wait for the confirm state (its Trust button). If it never arrives, dump the screen
+        // so the failure shows why (e.g. a connect Error message) rather than a bare timeout.
+        try {
+            compose.awaitText(str(R.string.connect_action_trust))
+        } catch (e: ComposeTimeoutException) {
+            throw AssertionError(
+                "Confirm state not reached after connect. Screen tree:\n" +
+                    compose.onRoot(useUnmergedTree = true).printToString(),
+                e,
+            )
+        }
+        // The confirm card shows the served leaf's fingerprint; asserting it matches the
+        // fixture's is the "confirm the certificate we were shown" check.
+        compose.onNodeWithText(server.fingerprint).assertExists()
         compose.onNodeWithText(str(R.string.connect_action_trust)).performClick()
 
         compose.awaitText(str(R.string.signin_action))

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -20,11 +20,14 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.text.input.ImeAction
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.MainActivity
 import io.github.xexanos.ratatoskr.R
+import io.github.xexanos.ratatoskr.RatatoskrApp
 import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import org.junit.Before
 import org.junit.Rule
@@ -187,7 +190,11 @@ class AppFlowTest {
         compose.onNodeWithContentDescription(str(R.string.library_settings)).performClick()
         compose.awaitText(str(R.string.settings_forget_cert))
         compose.onNodeWithText(str(R.string.settings_forget_cert)).performClick()
-        // Forgetting the certificate drops the trusted server and routes back to connect.
+        // Core effect: the pinned fingerprint is dropped. (Asserting the store also
+        // disambiguates a forget failure from a navigation failure in the next step.)
+        val container = ApplicationProvider.getApplicationContext<RatatoskrApp>().container
+        compose.waitUntil(5_000) { runBlocking { container.connectionStore.fingerprint() } == null }
+        // ...and the app routes back to connect for re-trust.
         compose.awaitText(str(R.string.connect_action_connect))
         compose.onNodeWithText(str(R.string.connect_action_connect)).assertIsDisplayed()
     }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasImeAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.text.input.ImeAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.xexanos.ratatoskr.MainActivity
+import io.github.xexanos.ratatoskr.R
+import io.github.xexanos.ratatoskr.network.WireFixtures
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import okhttp3.mockwebserver.MockResponse
+import org.junit.FixMethodOrder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+
+/**
+ * SPEC section 9, layer 3 - the whole app driven through its UI (the Playwright analogue).
+ * Each test launches the real [MainActivity] and taps/types through the actual screens; the
+ * app itself drives its real navigation -> ViewModels -> ConnectionManager -> core-network
+ * against a [HttpsMockServer] standing in for the Ratatoskr server.
+ *
+ * This layer asserts user-visible outcomes and flow; the wire-level mechanics (token rotation,
+ * error taxonomy, enum fallback, concurrency) are the component layer's job (see
+ * core-network `Factory*ComponentTest`) and are deliberately not re-checked here.
+ *
+ * Synchronisation: Material3 spinners animate forever, so `mainClock.autoAdvance = false`
+ * keeps idle-syncs from hanging on them, and [awaitTag]/[awaitText]/[awaitContentDescription]
+ * poll for the post-load nodes. Methods run in name order; `aSmoke...` runs first so a broken
+ * sync assumption fails fast and unambiguously.
+ */
+@RunWith(AndroidJUnit4::class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class AppFlowTest {
+
+    private val reset = ClearAppStateRule()
+    private val server = HttpsMockServer()
+    private val compose = createAndroidComposeRule<MainActivity>()
+
+    // reset (clear persisted state) -> start MockWebServer -> launch MainActivity.
+    @get:Rule
+    val chain: RuleChain = RuleChain.outerRule(reset).around(server).around(compose)
+
+    private fun str(id: Int): String = compose.activity.getString(id)
+
+    private fun installServer(dispatcher: RatatoskrDispatcher = RatatoskrDispatcher()) {
+        // autoAdvance off: otherwise the test clock chases the spinners' infinite animation and
+        // never idles, hanging every implicit sync. Nothing else drives the clock.
+        compose.mainClock.autoAdvance = false
+        server.server.dispatcher = dispatcher
+    }
+
+    /** Connect (type URL, confirm the shown certificate) then submit sign-in. */
+    private fun connectTrustAndSubmitSignIn() {
+        compose.awaitText(str(R.string.connect_action_connect))
+        compose.onNode(hasSetTextAction()).performTextReplacement(server.baseUrl)
+        compose.onNodeWithText(str(R.string.connect_action_connect)).performClick()
+
+        // The confirm card shows the served leaf's fingerprint - asserting it equals the
+        // fixture's is the "confirm the certificate we were shown" step.
+        compose.awaitText(server.fingerprint)
+        compose.onNodeWithText(server.fingerprint).assertIsDisplayed()
+        compose.onNodeWithText(str(R.string.connect_action_trust)).performClick()
+
+        compose.awaitText(str(R.string.signin_action))
+        compose.onNode(hasSetTextAction() and hasImeAction(ImeAction.Next)).performTextInput("lars")
+        compose.onNode(hasSetTextAction() and hasImeAction(ImeAction.Done)).performTextInput("secret")
+        compose.onNodeWithText(str(R.string.signin_action)).performClick()
+    }
+
+    @Test
+    fun aSmoke_appLaunchesToTheConnectScreen() {
+        installServer()
+        // If autoAdvance=false does not tame the startup spinner, this hangs to timeout and
+        // fails here - before any flow is attempted.
+        compose.awaitText(str(R.string.connect_action_connect))
+        compose.onNodeWithText(str(R.string.connect_action_connect)).assertIsDisplayed()
+    }
+
+    @Test
+    fun connectSignInLibrarySpeakersNowPlaying() {
+        installServer()
+        connectTrustAndSubmitSignIn()
+
+        // Library -> open the first book.
+        compose.awaitTag(UiTestTags.LIBRARY_ROW)
+        compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW)[0].performClick()
+
+        // Speakers -> pick the first speaker -> startSession -> Now playing.
+        compose.awaitTag(UiTestTags.SPEAKER_ROW)
+        compose.onAllNodesWithTag(UiTestTags.SPEAKER_ROW)[0].performClick()
+
+        // The first poll returns a playing session, so the control shows "Pause".
+        compose.awaitContentDescription(str(R.string.nowplaying_action_pause))
+
+        // Pause -> control flips to "Play".
+        compose.onNodeWithContentDescription(str(R.string.nowplaying_action_pause)).performClick()
+        compose.awaitContentDescription(str(R.string.nowplaying_action_play))
+
+        // Resume -> back to "Pause".
+        compose.onNodeWithContentDescription(str(R.string.nowplaying_action_play)).performClick()
+        compose.awaitContentDescription(str(R.string.nowplaying_action_pause))
+
+        // Seek: the slider is still playing afterwards (loose assertion - see plan risk 5).
+        compose.onNodeWithTag(UiTestTags.NOWPLAYING_SEEK)
+            .performSemanticsAction(SemanticsActions.SetProgress) { it(120f) }
+        compose.onNodeWithContentDescription(str(R.string.nowplaying_action_pause)).assertIsDisplayed()
+
+        // Stop -> back to the library.
+        compose.onNodeWithContentDescription(str(R.string.nowplaying_action_stop)).performClick()
+        compose.awaitTag(UiTestTags.LIBRARY_ROW)
+    }
+
+    @Test
+    fun connectRejectsAnUnreachableServer() {
+        installServer()
+        compose.awaitText(str(R.string.connect_action_connect))
+        // Nothing listens on :1, so certificate inspection fails -> the error/retry card.
+        compose.onNode(hasSetTextAction()).performTextReplacement("https://localhost:1")
+        compose.onNodeWithText(str(R.string.connect_action_connect)).performClick()
+        compose.awaitText(str(R.string.connect_action_retry))
+        compose.onNodeWithText(str(R.string.connect_action_retry)).assertIsDisplayed()
+    }
+
+    @Test
+    fun signInFailureKeepsTheUserOnSignIn() {
+        installServer(RatatoskrDispatcher(login = { MockResponse().setResponseCode(401) }))
+        connectTrustAndSubmitSignIn()
+        // Login was rejected: the sign-in action returns (not submitting) and we did not
+        // navigate to the library.
+        compose.awaitText(str(R.string.signin_action))
+        compose.onNodeWithText(str(R.string.signin_action)).assertIsDisplayed()
+        compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW).assertCountEquals(0)
+    }
+
+    @Test
+    fun emptyLibraryShowsTheEmptyState() {
+        installServer(RatatoskrDispatcher(libraryPage = WireFixtures.libraryPageJson(items = emptyList())))
+        connectTrustAndSubmitSignIn()
+        compose.awaitText(str(R.string.library_empty_title))
+        compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW).assertCountEquals(0)
+    }
+}

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -26,6 +26,7 @@ import io.github.xexanos.ratatoskr.R
 import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import okhttp3.mockwebserver.MockResponse
+import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
@@ -65,7 +66,14 @@ class AppFlowTest {
 
     private fun str(id: Int): String = compose.activity.getString(id)
 
-    private fun installServer(dispatcher: RatatoskrDispatcher = RatatoskrDispatcher()) {
+    // Every test starts with the happy-path server; a test needing different behaviour
+    // overrides it via useDispatcher(...). Runs after the rule chain has started the server.
+    @Before
+    fun installDefaultServer() {
+        server.server.dispatcher = RatatoskrDispatcher()
+    }
+
+    private fun useDispatcher(dispatcher: RatatoskrDispatcher) {
         server.server.dispatcher = dispatcher
     }
 
@@ -90,7 +98,6 @@ class AppFlowTest {
 
     @Test
     fun aSmoke_appLaunchesToTheConnectScreen() {
-        installServer()
         // Guards the whole sync approach: the app must render past its startup spinner to the
         // connect screen. If the wait strategy is wrong this fails here, before any flow.
         compose.awaitText(str(R.string.connect_action_connect))
@@ -99,7 +106,6 @@ class AppFlowTest {
 
     @Test
     fun connectSignInLibrarySpeakersNowPlaying() {
-        installServer()
         connectTrustAndSubmitSignIn()
 
         // Library -> open the first book.
@@ -134,7 +140,6 @@ class AppFlowTest {
 
     @Test
     fun connectRejectsAnUnreachableServer() {
-        installServer()
         compose.awaitText(str(R.string.connect_action_connect))
         // Nothing listens on :1, so certificate inspection fails -> the error/retry card.
         compose.onNode(hasSetTextAction()).performTextReplacement("https://localhost:1")
@@ -148,7 +153,7 @@ class AppFlowTest {
 
     @Test
     fun signInFailureKeepsTheUserOnSignIn() {
-        installServer(RatatoskrDispatcher(login = { MockResponse().setResponseCode(401) }))
+        useDispatcher(RatatoskrDispatcher(login = { MockResponse().setResponseCode(401) }))
         connectTrustAndSubmitSignIn()
         // Login was rejected: the sign-in action returns (not submitting) and we did not
         // navigate to the library.
@@ -159,7 +164,7 @@ class AppFlowTest {
 
     @Test
     fun emptyLibraryShowsTheEmptyState() {
-        installServer(RatatoskrDispatcher(libraryPage = WireFixtures.libraryPageJson(items = emptyList())))
+        useDispatcher(RatatoskrDispatcher(libraryPage = WireFixtures.libraryPageJson(items = emptyList())))
         connectTrustAndSubmitSignIn()
         compose.awaitText(str(R.string.library_empty_title))
         compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW).assertCountEquals(0)

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ClearAppStateRule.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ClearAppStateRule.kt
@@ -15,19 +15,16 @@ import org.junit.rules.ExternalResource
  * install (`MainActivity` routes to the connect screen). Must be the OUTER rule in the chain
  * so it runs before the activity launches.
  *
- * The reset goes through the process singleton container's OWN store instances - not by
- * deleting the DataStore files - because DataStore keeps an in-memory cache: a prior test's
+ * The reset goes through the process singleton container's own `reset()` - not by deleting
+ * the DataStore files - because DataStore keeps an in-memory cache: a prior test's
  * `saveTrustedServer` lives in that cache, and deleting the file on disk would not evict it,
  * so the next test would still read the stale server (a dead MockWebServer port) and skip
- * connect. `invalidate()` drops any client cached against that dead port.
+ * connect. Delegating to `AppContainer.reset()` keeps the set of cleared stores defined next
+ * to where the stores themselves are declared, so a newly added store is covered there.
  */
 class ClearAppStateRule : ExternalResource() {
     override fun before() {
         val app = ApplicationProvider.getApplicationContext<RatatoskrApp>()
-        runBlocking {
-            app.container.connectionStore.clear()
-            app.container.tokenStore.clear()
-        }
-        app.container.connectionManager.invalidate()
+        runBlocking { app.container.reset() }
     }
 }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ClearAppStateRule.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ClearAppStateRule.kt
@@ -1,0 +1,33 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui
+
+import androidx.test.core.app.ApplicationProvider
+import io.github.xexanos.ratatoskr.RatatoskrApp
+import kotlinx.coroutines.runBlocking
+import org.junit.rules.ExternalResource
+
+/**
+ * Resets the app's persisted state before each test, so every test starts from a clean
+ * install (`MainActivity` routes to the connect screen). Must be the OUTER rule in the chain
+ * so it runs before the activity launches.
+ *
+ * The reset goes through the process singleton container's OWN store instances - not by
+ * deleting the DataStore files - because DataStore keeps an in-memory cache: a prior test's
+ * `saveTrustedServer` lives in that cache, and deleting the file on disk would not evict it,
+ * so the next test would still read the stale server (a dead MockWebServer port) and skip
+ * connect. `invalidate()` drops any client cached against that dead port.
+ */
+class ClearAppStateRule : ExternalResource() {
+    override fun before() {
+        val app = ApplicationProvider.getApplicationContext<RatatoskrApp>()
+        runBlocking {
+            app.container.connectionStore.clear()
+            app.container.tokenStore.clear()
+        }
+        app.container.connectionManager.invalidate()
+    }
+}

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ComposeSync.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ComposeSync.kt
@@ -5,10 +5,13 @@
  */
 package io.github.xexanos.ratatoskr.ui
 
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.printToString
 
 /**
  * Data-driven waits for the UI integration suite.
@@ -19,15 +22,42 @@ import androidx.compose.ui.test.onAllNodesWithText
  * Material3 load spinners - which clear quickly because MockWebServer answers in milliseconds.
  * This is the reliable synchronisation primitive here; `waitForIdle` alone would risk hanging
  * while a spinner is briefly on screen.
+ *
+ * Every wait dumps the current semantics tree into the failure when it times out: a bare
+ * ComposeTimeoutException does not say which screen the app was on, whereas the tree turns any
+ * CI failure into a self-explaining one (it is what pinpointed the on-device certificate bug).
  */
 
 private const val DEFAULT_TIMEOUT_MS = 10_000L
 
 fun ComposeTestRule.awaitTag(tag: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MS) =
-    waitUntil(timeoutMillis) { onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty() }
+    awaitCondition("node with testTag '$tag'", timeoutMillis) {
+        onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
+    }
 
 fun ComposeTestRule.awaitText(text: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MS) =
-    waitUntil(timeoutMillis) { onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty() }
+    awaitCondition("node with text '$text'", timeoutMillis) {
+        onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+    }
 
 fun ComposeTestRule.awaitContentDescription(cd: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MS) =
-    waitUntil(timeoutMillis) { onAllNodesWithContentDescription(cd).fetchSemanticsNodes().isNotEmpty() }
+    awaitCondition("node with contentDescription '$cd'", timeoutMillis) {
+        onAllNodesWithContentDescription(cd).fetchSemanticsNodes().isNotEmpty()
+    }
+
+/** Waits for [condition], and on timeout fails with the rendered screen instead of a bare timeout. */
+private fun ComposeTestRule.awaitCondition(
+    description: String,
+    timeoutMillis: Long,
+    condition: () -> Boolean,
+) {
+    try {
+        waitUntil(timeoutMillis) { condition() }
+    } catch (e: ComposeTimeoutException) {
+        throw AssertionError(
+            "Timed out after ${timeoutMillis}ms waiting for $description. Current screen:\n" +
+                onRoot(useUnmergedTree = true).printToString(),
+            e,
+        )
+    }
+}

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ComposeSync.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ComposeSync.kt
@@ -1,0 +1,32 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+
+/**
+ * Data-driven waits for the UI integration suite.
+ *
+ * Screen content arrives from real MockWebServer responses (background call -> ViewModel
+ * StateFlow -> recomposition), not from the animation clock. The suite runs with
+ * `mainClock.autoAdvance = false` so the Material3 spinners' infinite animation never blocks
+ * idle; these helpers poll the semantics tree in real time via [ComposeTestRule.waitUntil]
+ * until the awaited node appears, which is the reliable synchronisation primitive here.
+ */
+
+private const val DEFAULT_TIMEOUT_MS = 10_000L
+
+fun ComposeTestRule.awaitTag(tag: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MS) =
+    waitUntil(timeoutMillis) { onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty() }
+
+fun ComposeTestRule.awaitText(text: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MS) =
+    waitUntil(timeoutMillis) { onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty() }
+
+fun ComposeTestRule.awaitContentDescription(cd: String, timeoutMillis: Long = DEFAULT_TIMEOUT_MS) =
+    waitUntil(timeoutMillis) { onAllNodesWithContentDescription(cd).fetchSemanticsNodes().isNotEmpty() }

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ComposeSync.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/ComposeSync.kt
@@ -14,10 +14,11 @@ import androidx.compose.ui.test.onAllNodesWithText
  * Data-driven waits for the UI integration suite.
  *
  * Screen content arrives from real MockWebServer responses (background call -> ViewModel
- * StateFlow -> recomposition), not from the animation clock. The suite runs with
- * `mainClock.autoAdvance = false` so the Material3 spinners' infinite animation never blocks
- * idle; these helpers poll the semantics tree in real time via [ComposeTestRule.waitUntil]
- * until the awaited node appears, which is the reliable synchronisation primitive here.
+ * StateFlow -> recomposition). [ComposeTestRule.waitUntil] advances the (auto-advancing) clock
+ * and re-checks the condition, so it sees the awaited node appear even across the transient
+ * Material3 load spinners - which clear quickly because MockWebServer answers in milliseconds.
+ * This is the reliable synchronisation primitive here; `waitForIdle` alone would risk hanging
+ * while a spinner is briefly on screen.
  */
 
 private const val DEFAULT_TIMEOUT_MS = 10_000L

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
@@ -28,7 +28,9 @@ class RatatoskrDispatcher(
 ) : Dispatcher() {
 
     @Volatile private var state = "playing"
-    @Volatile private var position = 10.0
+    // Low start position against a long duration (see session()) so the seek test can move the
+    // slider to a distinct value; a maxed-out slider would clamp SetProgress to a no-op.
+    @Volatile private var position = 30.0
 
     override fun dispatch(request: RecordedRequest): MockResponse {
         val path = request.path.orEmpty().substringBefore('?')
@@ -57,7 +59,8 @@ class RatatoskrDispatcher(
         }
     }
 
-    private fun session() = WireFixtures.sessionJson(state = state, positionSeconds = position)
+    private fun session() =
+        WireFixtures.sessionJson(state = state, positionSeconds = position, durationSeconds = 600.0)
 
     private companion object {
         val POSITION = Regex(""""positionSeconds"\s*:\s*([0-9.]+)""")

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
@@ -31,6 +31,9 @@ class RatatoskrDispatcher(
     // Low start position against a long duration (see session()) so the seek test can move the
     // slider to a distinct value; a maxed-out slider would clamp SetProgress to a no-op.
     @Volatile private var position = 30.0
+    // Once stopped (DELETE), a real server reports no active session; mirror that so a stray
+    // poll after Stop gets 404, not a revived session.
+    @Volatile private var ended = false
 
     override fun dispatch(request: RecordedRequest): MockResponse {
         val path = request.path.orEmpty().substringBefore('?')
@@ -43,11 +46,20 @@ class RatatoskrDispatcher(
             path.startsWith("/v1/library/items/") -> MockResponse().setResponseCode(404)
             path == "/v1/library/items" -> jsonResponse(libraryPage)
             path == "/v1/sessions/current" && request.method == "PUT" -> {
+                ended = false
                 state = "playing"
                 jsonResponse(session())
             }
-            path == "/v1/sessions/current" && request.method == "GET" -> jsonResponse(session())
-            path == "/v1/sessions/current" && request.method == "DELETE" -> MockResponse().setResponseCode(204)
+            path == "/v1/sessions/current" && request.method == "GET" ->
+                if (ended) {
+                    jsonResponse("""{"code":"no_active_session","message":"Nothing playing"}""", code = 404)
+                } else {
+                    jsonResponse(session())
+                }
+            path == "/v1/sessions/current" && request.method == "DELETE" -> {
+                ended = true
+                MockResponse().setResponseCode(204)
+            }
             path.endsWith("/pause") -> { state = "paused"; jsonResponse(session()) }
             path.endsWith("/resume") -> { state = "playing"; jsonResponse(session()) }
             path.endsWith("/seek") -> {

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
@@ -1,0 +1,68 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui
+
+import io.github.xexanos.ratatoskr.network.WireFixtures
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+
+/**
+ * A stateful MockWebServer dispatcher standing in for the Ratatoskr server across a whole-app
+ * flow. Path + method based (not enqueue) because a UI flow issues many requests in an order
+ * the test does not control (the now-playing screen also polls). It serves the root
+ * `GET /health` the connect screen's [io.github.xexanos.ratatoskr.network.tls.CertificateInspector]
+ * probes, plus the `/v1/` endpoints, and tracks playback `state`/`position` so pause/resume/
+ * seek produce a realistic session on the next poll.
+ *
+ * Response bodies come from the shared [WireFixtures]; [login] is injectable so a test can make
+ * sign-in fail.
+ */
+class RatatoskrDispatcher(
+    private val login: () -> MockResponse = { jsonResponse(WireFixtures.authTokensJson()) },
+    private val speakers: String = WireFixtures.speakerListJson(),
+    private val libraryPage: String = WireFixtures.libraryPageJson(),
+) : Dispatcher() {
+
+    @Volatile private var state = "playing"
+    @Volatile private var position = 10.0
+
+    override fun dispatch(request: RecordedRequest): MockResponse {
+        val path = request.path.orEmpty().substringBefore('?')
+        return when {
+            path == "/health" -> jsonResponse("""{"reachable":true}""")
+            path == "/v1/auth/login" -> login()
+            path == "/v1/speakers" -> jsonResponse(speakers)
+            // A library item tap navigates to the speaker picker, so the item-detail endpoint
+            // is not part of the happy path; answer defensively.
+            path.startsWith("/v1/library/items/") -> MockResponse().setResponseCode(404)
+            path == "/v1/library/items" -> jsonResponse(libraryPage)
+            path == "/v1/sessions/current" && request.method == "PUT" -> {
+                state = "playing"
+                jsonResponse(session())
+            }
+            path == "/v1/sessions/current" && request.method == "GET" -> jsonResponse(session())
+            path == "/v1/sessions/current" && request.method == "DELETE" -> MockResponse().setResponseCode(204)
+            path.endsWith("/pause") -> { state = "paused"; jsonResponse(session()) }
+            path.endsWith("/resume") -> { state = "playing"; jsonResponse(session()) }
+            path.endsWith("/seek") -> {
+                POSITION.find(request.body.readUtf8())?.groupValues?.get(1)?.toDoubleOrNull()
+                    ?.let { position = it }
+                jsonResponse(session())
+            }
+            else -> MockResponse().setResponseCode(404)
+        }
+    }
+
+    private fun session() = WireFixtures.sessionJson(state = state, positionSeconds = position)
+
+    private companion object {
+        val POSITION = Regex(""""positionSeconds"\s*:\s*([0-9.]+)""")
+    }
+}
+
+private fun jsonResponse(body: String, code: Int = 200): MockResponse =
+    MockResponse().setResponseCode(code).setHeader("Content-Type", "application/json").setBody(body)

--- a/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
@@ -9,8 +9,10 @@ import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
 import io.github.xexanos.ratatoskr.network.persist.TokenStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -51,7 +53,7 @@ class ConnectionManager(
             // Re-check inside the lock: another caller may have built it while we waited.
             cached?.let { if (it.key == key) return@withLock it.client }
             // A cached client for a different key is being replaced - release its HTTP stack.
-            cached?.client?.close()
+            cached?.client?.let { closeClient(it) }
             RatatoskrClientFactory.create(
                 baseUrl = config.baseUrl,
                 fingerprint = fingerprint,
@@ -64,8 +66,18 @@ class ConnectionManager(
     }
 
     /** Drop the cached client after the server or certificate changed, releasing its HTTP stack. */
-    fun invalidate() {
-        cached?.client?.close()
+    suspend fun invalidate() {
+        val toClose = cached?.client
         cached = null
+        toClose?.let { closeClient(it) }
+    }
+
+    // RatatoskrClient.close() evicts the OkHttp connection pool, which flushes and closes live
+    // TLS sockets - blocking network I/O. Callers invalidate from viewModelScope
+    // (Dispatchers.Main), so closing on the caller's thread throws NetworkOnMainThreadException
+    // (and would crash forget-certificate, where a live client exists). Tear down off the main
+    // thread.
+    private suspend fun closeClient(client: RatatoskrClient) {
+        withContext(Dispatchers.IO) { client.close() }
     }
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
@@ -10,6 +10,7 @@ import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
 import io.github.xexanos.ratatoskr.network.persist.TokenStore
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -65,19 +66,28 @@ class ConnectionManager(
         }
     }
 
-    /** Drop the cached client after the server or certificate changed, releasing its HTTP stack. */
+    /**
+     * Drop the cached client after the server or certificate changed, releasing its HTTP stack.
+     * Takes [buildMutex] so it cannot race a concurrent [client] build: without it, a build that
+     * started before this call could still overwrite [cached] with a client for the
+     * now-invalidated key after this call has cleared it.
+     */
     suspend fun invalidate() {
-        val toClose = cached?.client
-        cached = null
-        toClose?.let { closeClient(it) }
+        buildMutex.withLock {
+            val toClose = cached?.client
+            cached = null
+            toClose?.let { closeClient(it) }
+        }
     }
 
     // RatatoskrClient.close() evicts the OkHttp connection pool, which flushes and closes live
     // TLS sockets - blocking network I/O. Callers invalidate from viewModelScope
     // (Dispatchers.Main), so closing on the caller's thread throws NetworkOnMainThreadException
     // (and would crash forget-certificate, where a live client exists). Tear down off the main
-    // thread.
+    // thread. NonCancellable: this releases resources for a client that is already unreachable
+    // from `cached`, so it must run to completion even if the caller's coroutine (e.g. a
+    // ViewModel scope cleared by an activity recreation) is cancelled mid-close.
     private suspend fun closeClient(client: RatatoskrClient) {
-        withContext(Dispatchers.IO) { client.close() }
+        withContext(NonCancellable + Dispatchers.IO) { client.close() }
     }
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/di/AppContainer.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/di/AppContainer.kt
@@ -35,4 +35,15 @@ class AppContainer(context: Context) {
     val tokenStore = TokenStore(tokenDataStore, KeystoreCrypto())
     val certificateInspector = CertificateInspector()
     val connectionManager = ConnectionManager(connectionStore, tokenStore)
+
+    /**
+     * Clears all locally persisted state (trusted server + certificate, auth tokens) and drops
+     * the cached client. Lives next to the store declarations so a newly added store is covered
+     * here by construction; used by the instrumented tests to start each from a clean install.
+     */
+    suspend fun reset() {
+        connectionStore.clear()
+        tokenStore.clear()
+        connectionManager.invalidate()
+    }
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
@@ -1,0 +1,20 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui
+
+/**
+ * Stable Compose `testTag` handles for elements the UI integration tests must locate but that
+ * have no reliable text/semantics handle (dynamic list rows, a placeholder-only search field,
+ * an unlabelled slider). Kept in main so production composables and tests reference the same
+ * constants. Buttons, text fields with labels, and the transport controls are located by their
+ * existing text/contentDescription instead - see the integration suite.
+ */
+object UiTestTags {
+    const val LIBRARY_SEARCH = "library_search"
+    const val LIBRARY_ROW = "library_row"
+    const val SPEAKER_ROW = "speaker_row"
+    const val NOWPLAYING_SEEK = "nowplaying_seek"
+}

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -58,6 +59,7 @@ import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.LibraryItemSummary
 import io.github.xexanos.ratatoskr.network.domain.Progress
 import io.github.xexanos.ratatoskr.ui.EmptyState
+import io.github.xexanos.ratatoskr.ui.UiTestTags
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
 import io.github.xexanos.ratatoskr.ui.toMessage
 import kotlinx.coroutines.FlowPreview
@@ -199,7 +201,7 @@ private fun LibraryContent(
             },
             singleLine = true,
             shape = MaterialTheme.shapes.large,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(UiTestTags.LIBRARY_SEARCH),
         )
         when {
             state.loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -251,7 +253,7 @@ private fun LibraryRow(item: LibraryItemSummary, onClick: () -> Unit) {
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().testTag(UiTestTags.LIBRARY_ROW).clickable(onClick = onClick),
     ) {
         Row(
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
@@ -121,8 +121,13 @@ fun RatatoskrNavHost(container: AppContainer, startDestination: Route) {
                 viewModel = vm,
                 onReTrust = {
                     // Clear the whole back stack so Back can't return to authenticated screens.
+                    // launchSingleTop is required because Connect is the graph's start
+                    // destination in a first-run session: without it, popping the graph and
+                    // navigating to the start destination does not land on Connect (the screen
+                    // would stay on Settings).
                     navController.navigate(Route.Connect) {
                         popUpTo(navController.graph.id) { inclusive = true }
+                        launchSingleTop = true
                     }
                 },
                 onSignedOut = {

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -121,12 +122,13 @@ fun RatatoskrNavHost(container: AppContainer, startDestination: Route) {
                 viewModel = vm,
                 onReTrust = {
                     // Clear the whole back stack so Back can't return to authenticated screens.
-                    // launchSingleTop is required because Connect is the graph's start
-                    // destination in a first-run session: without it, popping the graph and
-                    // navigating to the start destination does not land on Connect (the screen
-                    // would stay on Settings).
+                    // Pop to the start destination inclusively (not the graph id): re-trust
+                    // navigates to Connect, which is the graph's start destination in a first-run
+                    // session, and popUpTo(graph.id) + navigate(startDestination) does not land
+                    // there (the screen stays on Settings). This is the canonical clear-and-reset
+                    // idiom that works for the start destination too.
                     navController.navigate(Route.Connect) {
-                        popUpTo(navController.graph.id) { inclusive = true }
+                        popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                         launchSingleTop = true
                     }
                 },

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
@@ -120,10 +120,8 @@ fun RatatoskrNavHost(container: AppContainer, startDestination: Route) {
             SettingsScreen(
                 viewModel = vm,
                 onReTrust = {
-                    // Clear the whole back stack so Back can't return to authenticated screens.
-                    // NOTE: in a first-run session Connect is the graph's start destination and
-                    // this does not actually land on Connect (the screen stays on Settings) -
-                    // a pre-existing re-trust navigation bug tracked separately; not fixed here.
+                    // Re-trust: return to the connect screen with an empty back stack, so Back
+                    // can't reach the now-untrusted authenticated screens.
                     navController.navigate(Route.Connect) {
                         popUpTo(navController.graph.id) { inclusive = true }
                     }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -122,14 +121,11 @@ fun RatatoskrNavHost(container: AppContainer, startDestination: Route) {
                 viewModel = vm,
                 onReTrust = {
                     // Clear the whole back stack so Back can't return to authenticated screens.
-                    // Pop to the start destination inclusively (not the graph id): re-trust
-                    // navigates to Connect, which is the graph's start destination in a first-run
-                    // session, and popUpTo(graph.id) + navigate(startDestination) does not land
-                    // there (the screen stays on Settings). This is the canonical clear-and-reset
-                    // idiom that works for the start destination too.
+                    // NOTE: in a first-run session Connect is the graph's start destination and
+                    // this does not actually land on Connect (the screen stays on Settings) -
+                    // a pre-existing re-trust navigation bug tracked separately; not fixed here.
                     navController.navigate(Route.Connect) {
-                        popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
-                        launchSingleTop = true
+                        popUpTo(navController.graph.id) { inclusive = true }
                     }
                 },
                 onSignedOut = {

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -60,6 +61,7 @@ import io.github.xexanos.ratatoskr.network.domain.LibraryItemSummary
 import io.github.xexanos.ratatoskr.network.domain.PlaybackState
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
 import io.github.xexanos.ratatoskr.network.domain.Session
+import io.github.xexanos.ratatoskr.ui.UiTestTags
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
 import io.github.xexanos.ratatoskr.ui.toMessage
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -289,7 +291,7 @@ private fun androidx.compose.foundation.layout.ColumnScope.NowPlayingContent(
         },
         valueRange = 0f..duration,
         colors = SliderDefaults.colors(),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().testTag(UiTestTags.NOWPLAYING_SEEK),
     )
     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         TimeLabel(sliderPosition.toDouble(), MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingScreen.kt
@@ -88,6 +88,12 @@ class NowPlayingViewModel(
     private val _uiState = MutableStateFlow(NowPlayingUiState())
     val uiState: StateFlow<NowPlayingUiState> = _uiState.asStateFlow()
 
+    // Monotonic counter of user control actions (pause/resume/seek). Each control bumps it; a
+    // poll snapshots it and drops its own result if a newer control was issued meanwhile - so a
+    // poll already in flight when the user pauses can't flip the control back to "playing". All
+    // access is on the main dispatcher (viewModelScope), so a plain Int needs no synchronisation.
+    private var commandEpoch = 0
+
     /**
      * Fetches the current session once. The screen drives this while it is RESUMED (see
      * [NowPlayingScreen]) instead of a self-running loop, so polling stops when the app is
@@ -96,23 +102,31 @@ class NowPlayingViewModel(
      */
     suspend fun refresh() {
         if (_uiState.value.stopped) return
+        val epoch = commandEpoch
         val client = connectionManager.client() ?: return
         when (val result = client.currentSession()) {
-            is ApiResult.Success -> applySession(result.data)
-            is ApiResult.Failure -> when (result.error) {
-                is RatatoskrError.NoActiveSession ->
-                    _uiState.value = _uiState.value.copy(loading = false, session = null)
-                else ->
-                    _uiState.value = _uiState.value.copy(loading = false, error = result.error.toMessage())
+            is ApiResult.Success -> applySession(result.data, epoch)
+            is ApiResult.Failure -> {
+                // A control action issued while this poll was in flight takes precedence.
+                if (epoch != commandEpoch || _uiState.value.stopped) return
+                when (result.error) {
+                    is RatatoskrError.NoActiveSession ->
+                        _uiState.value = _uiState.value.copy(loading = false, session = null)
+                    else ->
+                        _uiState.value = _uiState.value.copy(loading = false, error = result.error.toMessage())
+                }
             }
         }
     }
 
-    private fun applySession(session: Session) {
+    private fun applySession(session: Session, epoch: Int) {
         // A poll or control response that completes after stop() must not revive the ended
         // session: the `stopped` guard in refresh() only covers the start of the call, not the
         // apply after the network await, and stop() has already navigated away.
         if (_uiState.value.stopped) return
+        // Drop a result the user's latest control action has already superseded (e.g. a poll
+        // that was in flight when the user paused), so it can't revert the just-set state.
+        if (epoch != commandEpoch) return
         // The server owns token rotation while a session is active (SPEC section 5).
         val active = session.state in ACTIVE_STATES
         connectionManager.setSessionActive(active)
@@ -142,15 +156,19 @@ class NowPlayingViewModel(
     }
 
     private fun control(action: suspend (io.github.xexanos.ratatoskr.network.api.RatatoskrClient) -> ApiResult<Session>) {
+        val epoch = ++commandEpoch
         viewModelScope.launch {
             // Clear a stale error when the user starts a new action, so a later successful poll
             // is not what makes the old message disappear.
             _uiState.value = _uiState.value.copy(error = null)
             val client = connectionManager.client() ?: return@launch
             when (val result = action(client)) {
-                is ApiResult.Success -> applySession(result.data)
+                is ApiResult.Success -> applySession(result.data, epoch)
+                // Only surface this action's error if a newer control hasn't superseded it.
                 is ApiResult.Failure ->
-                    _uiState.value = _uiState.value.copy(error = result.error.toMessage())
+                    if (epoch == commandEpoch) {
+                        _uiState.value = _uiState.value.copy(error = result.error.toMessage())
+                    }
             }
         }
     }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/speakers/SpeakersScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/speakers/SpeakersScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -48,6 +49,7 @@ import io.github.xexanos.ratatoskr.data.ConnectionManager
 import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.Speaker
 import io.github.xexanos.ratatoskr.ui.EmptyState
+import io.github.xexanos.ratatoskr.ui.UiTestTags
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
 import io.github.xexanos.ratatoskr.ui.toMessage
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -180,7 +182,7 @@ private fun SpeakerRow(speaker: Speaker, onClick: () -> Unit) {
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().testTag(UiTestTags.SPEAKER_ROW).clickable(onClick = onClick),
     ) {
         Row(
             modifier = Modifier.padding(12.dp),

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -81,6 +81,14 @@ dependencies {
     api(libs.kotlinx.coroutines.core)
     implementation(libs.androidx.datastore.preferences)
 
+    // Shared test fixtures (FakeTokenAccess, WireFixtures, HttpsMockServer) consumed by this
+    // module's unit + instrumented tests AND the :app UI integration tests. HttpsMockServer's
+    // public surface exposes JUnit's ExternalResource and MockWebServer/okhttp-tls types, so
+    // these are `api` (transitive to consumers), not `implementation`.
+    testFixturesApi(libs.junit)
+    testFixturesApi(libs.okhttp.mockwebserver)
+    testFixturesApi(libs.okhttp.tls)
+
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.okhttp.mockwebserver)

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -83,11 +83,12 @@ dependencies {
 
     // Shared test fixtures (FakeTokenAccess, WireFixtures, HttpsMockServer) consumed by this
     // module's unit + instrumented tests AND the :app UI integration tests. HttpsMockServer's
-    // public surface exposes JUnit's ExternalResource and MockWebServer/okhttp-tls types, so
-    // these are `api` (transitive to consumers), not `implementation`.
+    // PUBLIC surface exposes JUnit's ExternalResource (superclass) and MockWebServer/MockResponse
+    // (return types), so those are `api`. okhttp-tls (HeldCertificate/HandshakeCertificates) is
+    // used only in private members, so it stays `implementation` - consumers don't need it.
     testFixturesApi(libs.junit)
     testFixturesApi(libs.okhttp.mockwebserver)
-    testFixturesApi(libs.okhttp.tls)
+    testFixturesImplementation(libs.okhttp.tls)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.core)

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
@@ -5,8 +5,6 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
-import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
-
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures
@@ -14,6 +12,7 @@ import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import org.junit.Assert.assertEquals

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
@@ -5,6 +5,8 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryDeserializationComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryDeserializationComponentTest.kt
@@ -5,8 +5,6 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
-import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
-
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures
@@ -14,6 +12,7 @@ import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.PlaybackState
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryDeserializationComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryDeserializationComponentTest.kt
@@ -5,6 +5,8 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
@@ -5,14 +5,13 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
-import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
-
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
@@ -5,6 +5,8 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactorySessionRotationComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactorySessionRotationComponentTest.kt
@@ -68,7 +68,7 @@ class FactorySessionRotationComponentTest {
         val store = TokenStore(dataStore, KeystoreCrypto(keyAlias = "ratatoskr.test.$name"))
         runBlocking {
             store.clear()
-            store.save(AuthSession("a0", "r0", AuthUser("7", "lars")))
+            store.save(AuthSession("a0", "r0", AuthUser("7", "alex")))
         }
         return store
     }

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactorySessionRotationComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactorySessionRotationComponentTest.kt
@@ -5,8 +5,6 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
-import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
-
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +17,7 @@ import io.github.xexanos.ratatoskr.network.domain.AuthSession
 import io.github.xexanos.ratatoskr.network.domain.AuthUser
 import io.github.xexanos.ratatoskr.network.persist.KeystoreCrypto
 import io.github.xexanos.ratatoskr.network.persist.TokenStore
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactorySessionRotationComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactorySessionRotationComponentTest.kt
@@ -5,6 +5,8 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
@@ -5,14 +5,13 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
-import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
-
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Rule

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
@@ -5,6 +5,8 @@
  */
 package io.github.xexanos.ratatoskr.network.component
 
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/tls/CertificateInspector.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/tls/CertificateInspector.kt
@@ -25,7 +25,7 @@ import javax.net.ssl.X509TrustManager
 class CertificateInspector {
 
     suspend fun inspect(baseUrl: String): CertificateInfo = withContext(Dispatchers.IO) {
-        val trustAll = TrustAllManager()
+        val trustAll = CapturingTrustManager()
         val sslContext = SSLContext.getInstance("TLS").apply {
             init(null, arrayOf(trustAll), java.security.SecureRandom())
         }
@@ -40,12 +40,19 @@ class CertificateInspector {
         try {
             val request = Request.Builder().url(healthUrl(baseUrl)).build()
             client.newCall(request).execute().use { response ->
-                val peer = response.handshake?.peerCertificates
-                    ?: error("No TLS handshake; is the server serving HTTPS?")
-                val leaf = peer.firstOrNull() as? X509Certificate
-                    ?: error("Server presented no X.509 certificate.")
-                leaf.toCertificateInfo()
+                if (response.handshake == null) {
+                    error("No TLS handshake; is the server serving HTTPS?")
+                }
             }
+            // Read the leaf from what the trust manager captured DURING the handshake, not from
+            // Response.handshake.peerCertificates: on Android's Conscrypt the latter comes back
+            // empty for a trust-all manager (the peer is treated as unverified, so OkHttp
+            // yields no peer certificates), which would break trust-on-first-use on device.
+            // The trust manager callback receives the real chain - the same path PinnedTrustManager
+            // relies on (SPEC section 6).
+            val leaf = trustAll.leaf
+                ?: error("Server presented no X.509 certificate.")
+            leaf.toCertificateInfo()
         } finally {
             client.dispatcher.executorService.shutdown()
             client.connectionPool.evictAll()
@@ -65,9 +72,21 @@ class CertificateInspector {
         sha256Fingerprint = Fingerprints.sha256(this),
     )
 
-    private class TrustAllManager : X509TrustManager {
+    /**
+     * Trusts every certificate (this client only ever reads the chain, never carries real
+     * traffic) and captures the leaf the server presents during the handshake, which is the
+     * reliable way to read it on Conscrypt.
+     */
+    private class CapturingTrustManager : X509TrustManager {
+        @Volatile var leaf: X509Certificate? = null
+            private set
+
         override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
-        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+
+        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+            if (leaf == null) leaf = chain?.firstOrNull()
+        }
+
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
     }
 }

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -62,12 +62,12 @@ class RatatoskrClientTest {
     fun `login stores the returned token pair`() = runBlocking {
         server.enqueue(MockResponse().setBody(WireFixtures.authTokensJson()))
 
-        val result = client.login("lars", "secret")
+        val result = client.login("alex", "secret")
 
         assertTrue(result is ApiResult.Success)
         assertEquals("a1", tokens.currentAccessTokenBlocking())
         assertEquals("r1", tokens.refreshToken())
-        assertEquals("lars", tokens.savedSession!!.user.username)
+        assertEquals("alex", tokens.savedSession!!.user.username)
     }
 
     @Test

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/TokenRefreshAuthenticatorTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/TokenRefreshAuthenticatorTest.kt
@@ -40,7 +40,7 @@ class TokenRefreshAuthenticatorTest {
     }
 
     private fun renewed(access: String) =
-        AuthSession(access, "refresh-next", AuthUser("1", "lars"))
+        AuthSession(access, "refresh-next", AuthUser("1", "alex"))
 
     private fun client(
         tokens: FakeTokenAccess,

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
@@ -36,7 +36,7 @@ object WireFixtures {
     fun authTokensJson(
         accessToken: String = "a1",
         refreshToken: String = "r1",
-        username: String = "lars",
+        username: String = "alex",
     ): String =
         """{"accessToken":"$accessToken","refreshToken":"$refreshToken",""" +
             """"user":{"id":"7","username":"$username"}}"""

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
@@ -10,6 +10,9 @@ package io.github.xexanos.ratatoskr.network
  * by the JVM unit tests and the instrumented integration tests. One definition per shape:
  * when the contract changes, this file changes - not a dozen inline JSON literals across
  * two source sets, where a missed copy keeps a test green against an outdated shape.
+ *
+ * String values are JSON-escaped (see [esc]) so a caller passing a title/name with a quote or
+ * backslash still produces valid JSON instead of a body that fails to deserialize far away.
  */
 object WireFixtures {
 
@@ -26,10 +29,10 @@ object WireFixtures {
         extraJson: String = "",
     ): String {
         val rotated = rotatedTokens?.let { (access, refresh) ->
-            ""","rotatedTokens":{"accessToken":"$access","refreshToken":"$refresh"}"""
+            ""","rotatedTokens":{"accessToken":"${esc(access)}","refreshToken":"${esc(refresh)}"}"""
         } ?: ""
         val extra = if (extraJson.isEmpty()) "" else ",$extraJson"
-        return """{"itemId":"i1","speakerId":"s1","state":"$state","positionSeconds":$positionSeconds,""" +
+        return """{"itemId":"i1","speakerId":"s1","state":"${esc(state)}","positionSeconds":$positionSeconds,""" +
             """"durationSeconds":$durationSeconds,"updatedAt":"2026-07-05T12:00:00Z"$rotated$extra}"""
     }
 
@@ -39,8 +42,8 @@ object WireFixtures {
         refreshToken: String = "r1",
         username: String = "alex",
     ): String =
-        """{"accessToken":"$accessToken","refreshToken":"$refreshToken",""" +
-            """"user":{"id":"7","username":"$username"}}"""
+        """{"accessToken":"${esc(accessToken)}","refreshToken":"${esc(refreshToken)}",""" +
+            """"user":{"id":"7","username":"${esc(username)}"}}"""
 
     /** A single `Speaker` wire object. */
     fun speakerJson(
@@ -49,8 +52,8 @@ object WireFixtures {
         isGroup: Boolean = false,
         members: List<String> = emptyList(),
     ): String {
-        val m = members.joinToString(",") { "\"$it\"" }
-        return """{"id":"$id","name":"$name","isGroup":$isGroup,"members":[$m]}"""
+        val m = members.joinToString(",") { "\"${esc(it)}\"" }
+        return """{"id":"${esc(id)}","name":"${esc(name)}","isGroup":$isGroup,"members":[$m]}"""
     }
 
     /** A `GET /v1/speakers` response body (a JSON array of speakers). */
@@ -64,8 +67,8 @@ object WireFixtures {
         author: String? = "J. R. R. Tolkien",
         durationSeconds: Double = 39_600.0,
     ): String {
-        val a = author?.let { ""","author":"$it"""" } ?: ""
-        return """{"id":"$id","title":"$title"$a,"durationSeconds":$durationSeconds}"""
+        val a = author?.let { ""","author":"${esc(it)}"""" } ?: ""
+        return """{"id":"${esc(id)}","title":"${esc(title)}"$a,"durationSeconds":$durationSeconds}"""
     }
 
     /** A `GET /v1/library/items` response body (a `LibraryItemPage`). */
@@ -73,7 +76,11 @@ object WireFixtures {
         items: List<String> = listOf(libraryItemSummaryJson()),
         nextCursor: String? = null,
     ): String {
-        val c = nextCursor?.let { ""","nextCursor":"$it"""" } ?: ""
+        val c = nextCursor?.let { ""","nextCursor":"${esc(it)}"""" } ?: ""
         return """{"items":[${items.joinToString(",")}]$c}"""
     }
+
+    /** Minimal JSON string escaping for interpolated values: backslash and double-quote. */
+    private fun esc(value: String): String =
+        value.replace("\\", "\\\\").replace("\"", "\\\"")
 }

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
@@ -21,6 +21,7 @@ object WireFixtures {
     fun sessionJson(
         state: String = "playing",
         positionSeconds: Double = 1.0,
+        durationSeconds: Double = 10.0,
         rotatedTokens: Pair<String, String>? = null,
         extraJson: String = "",
     ): String {
@@ -29,7 +30,7 @@ object WireFixtures {
         } ?: ""
         val extra = if (extraJson.isEmpty()) "" else ",$extraJson"
         return """{"itemId":"i1","speakerId":"s1","state":"$state","positionSeconds":$positionSeconds,""" +
-            """"durationSeconds":10.0,"updatedAt":"2026-07-05T12:00:00Z"$rotated$extra}"""
+            """"durationSeconds":$durationSeconds,"updatedAt":"2026-07-05T12:00:00Z"$rotated$extra}"""
     }
 
     /** An `AuthTokens` response body, as returned by login and refresh. */

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
@@ -40,4 +40,39 @@ object WireFixtures {
     ): String =
         """{"accessToken":"$accessToken","refreshToken":"$refreshToken",""" +
             """"user":{"id":"7","username":"$username"}}"""
+
+    /** A single `Speaker` wire object. */
+    fun speakerJson(
+        id: String = "s1",
+        name: String = "Living Room",
+        isGroup: Boolean = false,
+        members: List<String> = emptyList(),
+    ): String {
+        val m = members.joinToString(",") { "\"$it\"" }
+        return """{"id":"$id","name":"$name","isGroup":$isGroup,"members":[$m]}"""
+    }
+
+    /** A `GET /v1/speakers` response body (a JSON array of speakers). */
+    fun speakerListJson(vararg speakers: String = arrayOf(speakerJson())): String =
+        "[${speakers.joinToString(",")}]"
+
+    /** A single `LibraryItemSummary` wire object (cover/progress omitted - optional). */
+    fun libraryItemSummaryJson(
+        id: String = "i1",
+        title: String = "The Hobbit",
+        author: String? = "J. R. R. Tolkien",
+        durationSeconds: Double = 39_600.0,
+    ): String {
+        val a = author?.let { ""","author":"$it"""" } ?: ""
+        return """{"id":"$id","title":"$title"$a,"durationSeconds":$durationSeconds}"""
+    }
+
+    /** A `GET /v1/library/items` response body (a `LibraryItemPage`). */
+    fun libraryPageJson(
+        items: List<String> = listOf(libraryItemSummaryJson()),
+        nextCursor: String? = null,
+    ): String {
+        val c = nextCursor?.let { ""","nextCursor":"$it"""" } ?: ""
+        return """{"items":[${items.joinToString(",")}]$c}"""
+    }
 }

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/testutil/HttpsMockServer.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/testutil/HttpsMockServer.kt
@@ -3,7 +3,7 @@
  * Copyright (C) 2026  Ratatoskr contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-package io.github.xexanos.ratatoskr.network.component
+package io.github.xexanos.ratatoskr.network.testutil
 
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.tls.Fingerprints


### PR DESCRIPTION
## Why

Adds the missing **integration** layer from SPEC section 9: the whole app driven through its UI (the Playwright analogue). Complements — does not duplicate — the component tests from #8: those go deep on the network/trust mechanics below the UI; this goes broad across the assembled user flow.

## What

Instrumented Compose UI tests in `:app` that launch the real `MainActivity` and tap/type through the actual screens, so the app itself drives navigation → ViewModels → `ConnectionManager` → core-network against a `MockWebServer` standing in for the Ratatoskr server.

- **`AppFlowTest`** — full happy path: connect → confirm the shown certificate → sign in → library → pick a speaker → now playing (pause / resume / seek / stop). Plus alternates: unreachable server at connect, sign-in failure, empty library. A `aSmoke_…` test runs first and fails fast if the sync approach breaks.
- **`ClearAppStateRule`** — cache-safe per-test reset through the container's own DataStore instances (deleting files would not evict DataStore's in-process cache).
- **`RatatoskrDispatcher`** — stateful path+method MockWebServer dispatcher: root `GET /health` for certificate inspection plus the v1 endpoints, reusing the shared `WireFixtures`.
- **`ComposeSync`** — `waitUntil`-based helpers; the clock is left auto-advancing (freezing it also freezes recomposition). Every wait dumps the current semantics tree on timeout, so a CI failure shows the screen state, not a bare timeout.

## Two real production bugs surfaced on device

This layer earned its keep immediately — both are on paths a JVM test structurally cannot exercise:

1. **401 refresh deadlock** (fixed in #8, reproduced by the component single-flight test): the auth and main OkHttp clients shared one dispatcher, so under concurrent 401s the refresh could never get a request slot.
2. **TOFU certificate inspection broken on Conscrypt** (fixed here, `23ac415`): `CertificateInspector` read the leaf from `Response.handshake.peerCertificates`, which comes back empty for a trust-all manager on Android — the connect screen would never show a fingerprint on a real device. Now captured in the trust manager's `checkServerTrusted` callback (the path `PinnedTrustManager` already uses on device).

## Supporting changes

- Shared `HttpsMockServer` moved to `core-network` test fixtures (`network.testutil`); `WireFixtures` extended with speaker/library builders; consumed by both suites.
- Four `testTag`s added to production composables (library search + rows, speaker rows, seek slider) — semantics-only, no runtime/visual effect; the accessibility suite is unaffected.
- CI: the emulator job runs `AppFlowTest` once (theme-independent) alongside the component and accessibility suites.

## Verification

Green on the emulator CI job: all five UI flows pass, alongside the component and accessibility suites. Local: compiles, UX/ASCII gate green, JVM unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)