### PR TITLE
ci: stop building PR commits twice (scope push to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
-# Builds the app and runs the unit tests on every push and every pull request, so a
-# change can't merge without compiling and passing tests. No branch filter: pushes to any
-# branch run too, so work on stacked/feature branches (and PRs targeting them) is covered.
+# Builds the app and runs the unit tests, so a change can't merge without compiling and
+# passing tests. push builds only main; every pull request builds its head. Feature-branch
+# work is covered by its PR - a branch with no open PR does not build. Scoping push to main
+# is deliberate: a push to a PR branch would otherwise fire BOTH the push and pull_request
+# events and build the same commit twice (leaving a cancelled duplicate run on the PR).
 # Free-software toolchain only (SPEC section 8): official GitHub-hosted runner, Temurin
 # JDK, Gradle wrapper - no proprietary SDKs.
 #
@@ -13,6 +15,7 @@ name: CI
 # protection, a docs-only PR would show no CI run; use a companion always-pass job then.)
 on:
   push:
+    branches: [main]
     paths-ignore: &docs-only
       - '**/*.md'
       - 'docs/**'
@@ -26,9 +29,9 @@ permissions:
   contents: read
 
 concurrency:
-  # Key on the head branch (not the ref) so a branch's push event and its pull_request
-  # event collapse into one group - cancel-in-progress then keeps a single run instead of
-  # building the same commit twice now that there is no branch filter.
+  # push (main) and pull_request no longer fire for the same commit, so there is no push/PR
+  # duplicate to collapse here; this just cancels a superseded run when new commits land in
+  # quick succession on the same PR (or on main).
   group: ci-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 


### PR DESCRIPTION
## Why

Every PR showed a stray cancelled "Build & unit test" run — an 8-second red check that made the PR `UNSTABLE`. `ci.yml` listened on **both** `push` and `pull_request`, so a push to a branch with an open PR fired both events and built the same commit twice. The `concurrency` group cancelled one of them, but the cancelled run stayed visible on the PR as a failed check.

## What

Scope the `push` trigger to `main`:

```yaml
on:
  push:
    branches: [main]
    paths-ignore: *docs-only
  pull_request:
    paths-ignore: *docs-only
```

Now a push to a PR branch fires only the `pull_request` event → each commit builds once. `main` (post-merge) still builds via `push`.

## Trade-off (chosen deliberately)

- A branch with **no open PR** no longer builds on push — its build comes when a PR is opened. (Previously CI ran on every branch push.)
- **Fork PRs still build** via `pull_request`.

This is the standard GitHub Actions trigger model. Only `ci.yml` was affected; `instrumented-tests.yml` already listens on `pull_request` only.

Note: this PR should itself show a single CI run (no cancelled duplicate), since the branch's own updated `ci.yml` no longer fires `push` for a non-`main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)