### PR TITLE
fix(tls): throw CertificateException for empty cert chain in PinnedTrustManager

### DIFF
--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/tls/PinnedTrustManager.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/tls/PinnedTrustManager.kt
@@ -40,6 +40,13 @@ class PinnedTrustManager(
     }
 
     override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String?) {
+        // Reject an empty chain ourselves, before delegating: the platform trust manager throws
+        // IllegalArgumentException (a RuntimeException) for a zero-length chain, which would
+        // escape the CertificateException catch below and surface to callers as an opaque error
+        // instead of the CertificateException every TOFU trust failure is contracted to throw.
+        if (chain.isEmpty()) {
+            throw CertificateException("Server presented an empty certificate chain.")
+        }
         try {
             platform.checkServerTrusted(chain, authType)
             return
@@ -49,8 +56,7 @@ class PinnedTrustManager(
                     "Server certificate is not trusted and no fingerprint has been confirmed yet.",
                     platformFailure,
                 )
-            val leaf = chain.firstOrNull()
-                ?: throw CertificateException("Server presented an empty certificate chain.", platformFailure)
+            val leaf = chain.first()
             if (!Fingerprints.matches(Fingerprints.sha256(leaf), pin)) {
                 throw CertificateException(
                     "Server certificate fingerprint does not match the confirmed one. " +

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/tls/PinnedTrustManagerTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/tls/PinnedTrustManagerTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.tls
+
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PinnedTrustManagerTest {
+
+    /**
+     * An empty chain must fail as a [CertificateException] - the type every TOFU trust failure is
+     * contracted to throw and the only type [io.github.xexanos.ratatoskr.network.api.RatatoskrClient]
+     * maps to CertificateUntrusted. Guarding it ourselves is what makes this hold: delegating to
+     * the platform trust manager would raise IllegalArgumentException (a RuntimeException), which
+     * escapes the CertificateException catch and surfaces to callers as an opaque Unexpected error.
+     * The guarantee must not depend on whether a pin has been confirmed, so both cases are checked.
+     */
+    @Test
+    fun `empty certificate chain throws CertificateException regardless of pin`() {
+        val emptyChain = emptyArray<X509Certificate>()
+
+        assertThrows(CertificateException::class.java) {
+            PinnedTrustManager(expectedFingerprint = null).checkServerTrusted(emptyChain, "RSA")
+        }
+        assertThrows(CertificateException::class.java) {
+            PinnedTrustManager(expectedFingerprint = "AA:BB").checkServerTrusted(emptyChain, "RSA")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`PinnedTrustManager.checkServerTrusted` delegated to the platform trust manager *before* its own empty-chain guard (`chain.firstOrNull() ?: throw CertificateException(...)`) could run. For a zero-length chain, the JDK's `X509TrustManagerImpl` throws `IllegalArgumentException("null or zero-length certificate chain")` — a `RuntimeException`, not a `CertificateException` — so the guard was **dead code** and the `IllegalArgumentException` escaped the `catch (platformFailure: CertificateException)` block, violating the class's documented contract that every TOFU trust failure throws `CertificateException`.

## Consumer impact

No crash today: `RatatoskrClient.execute`/`executeNullable` wrap calls in `catch (t: Throwable)`. But `mapThrowable` only maps `CertificateException` / `SSLPeerUnverifiedException` / `SSLHandshakeException` to `RatatoskrError.CertificateUntrusted`; an `IllegalArgumentException` falls through to `RatatoskrError.Unexpected`, so it would surface as a generic error and miss the connect/re-trust flow. An empty chain can't realistically occur in a live TLS handshake (low production risk), but the fix is cheap and restores the contract uniformly.

## Change

- Guard `chain.isEmpty()` at the top of `checkServerTrusted`, throwing `CertificateException` directly and independently of whether a pin is confirmed.
- Simplify the now-guaranteed-non-empty lookup from `firstOrNull() ?: throw …` to `first()`.
- Add a JVM unit test covering both the pinned and unpinned cases.

## Testing

`:core-network:testDebugUnitTest --tests "...PinnedTrustManagerTest"` — passes.

> Note: branch `test/tls-fingerprint-unit` has a test asserting the old `IllegalArgumentException` behavior; if it merges, that assertion needs updating to `CertificateException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)