### PR TITLE
docs: correct testing.md status (whole-app + light/dark a11y present)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,10 +68,10 @@ The strategy above is the target. Current state:
 
 - **Present:** `core-network` unit tests (JUnit4 + MockWebServer); instrumented
   component tests (auth, deserialization, error mapping, session rotation, TLS
-  pinning); accessibility checks across every screen (ATF, WARNING threshold incl.
-  contrast) in the emulator's default theme.
-- **In progress:** the whole-app Compose integration flow.
-- **To add:** running the accessibility checks in both light and dark themes
-  (today each screen preview is checked once, in the system default theme);
-  exposing `testTagsAsResourceId` + `testTag`s for black-box driving; running the
-  instrumented suite on both API 26 and API 36.
+  pinning); the whole-app Compose integration flow (`AppFlowTest`); accessibility
+  checks across every screen (ATF, WARNING threshold incl. contrast) in **both**
+  light and dark themes — the CI script toggles `adb shell cmd uimode night no/yes`
+  around two separate `AccessibilityChecksTest` runs, the second forced with
+  `--rerun` so Gradle can't skip it as up-to-date.
+- **To add:** exposing `testTagsAsResourceId` + `testTag`s for black-box driving;
+  running the instrumented suite on both API 26 and API 36.


### PR DESCRIPTION
Aligns `docs/testing.md`'s status section with what actually ships today.

- The whole-app Compose integration flow (`AppFlowTest`) landed in #9 but was still listed as "in progress".
- Light/dark accessibility has run in CI since before this doc existed — the instrumented workflow toggles `adb shell cmd uimode night no/yes` around two `AccessibilityChecksTest` runs (the second forced with `--rerun`), and `RatatoskrTheme` defaults `darkTheme = isSystemInDarkTheme()` so the device mode actually propagates. It was wrongly listed under "To add".

Docs-only; no code change.

## Part of a batch
One of five small PRs aligning the codebase with `docs/testing.md`. Each touches its own status line in `docs/testing.md`, so expect a trivial one-line merge conflict there as siblings land — resolve by keeping every "Present" addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)