### PR TITLE
feat: expose testTags as resource-ids for black-box E2E driving

### DIFF
--- a/app/src/main/java/io/github/xexanos/ratatoskr/MainActivity.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/MainActivity.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import io.github.xexanos.ratatoskr.di.AppContainer
 import io.github.xexanos.ratatoskr.ui.navigation.RatatoskrNavHost
 import io.github.xexanos.ratatoskr.ui.navigation.Route
@@ -38,7 +40,14 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             RatatoskrTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                Scaffold(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        // Bridges Compose testTags to UiAutomator resource-ids so the
+                        // black-box E2E harness (ratatoskr-e2e, Maestro/UiAutomator) can
+                        // locate the same elements the Compose UI tests find by testTag.
+                        .semantics { testTagsAsResourceId = true },
+                ) { innerPadding ->
                     Surface(modifier = Modifier.padding(innerPadding)) {
                         // Resolve the start route off the main thread (see decideStartDestination),
                         // showing a brief loader instead of blocking onCreate.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,6 +74,7 @@ The strategy above is the target. Current state:
   checks across every screen (ATF, WARNING threshold incl. contrast) in **both**
   light and dark themes — the CI script toggles `adb shell cmd uimode night no/yes`
   around two separate `AccessibilityChecksTest` runs, the second forced with
-  `--rerun` so Gradle can't skip it as up-to-date.
-- **To add:** exposing `testTagsAsResourceId` + `testTag`s for black-box driving;
-  running the instrumented suite on both API 26 and API 36.
+  `--rerun` so Gradle can't skip it as up-to-date; `testTagsAsResourceId` set high
+  in the hierarchy (`MainActivity`) so the existing `testTag`s are also visible to
+  the black-box E2E harness.
+- **To add:** running the instrumented suite on both API 26 and API 36.


### PR DESCRIPTION
The central E2E harness (`ratatoskr-e2e`, Maestro/UiAutomator over the built `.apk`) needs `Modifier.semantics { testTagsAsResourceId = true }` set high in the tree so the app's existing `testTag`s surface as UiAutomator resource-ids — Compose test tags alone are invisible to black-box tools. This was listed as an open point in the central test concept (§9) and never set anywhere in the app.

- `MainActivity`: sets the flag on the root `Scaffold` inside `setContent { RatatoskrTheme { … } }` — as high as possible, theme untouched. No test tags added or renamed; the existing four in `UiTestTags.kt` are unchanged.

## Verification
- `AppFlowTest` 7/7 green — no composition regression from the wrapping change (`onNodeWithTag` lookups are independent of this flag).
- Confirmed live: with the app on Library, `adb shell uiautomator dump` now shows `resource-id="library_row"` and `resource-id="library_search"` on the real nodes (empty on `main`).

## Part of a batch
One of five small PRs aligning the codebase with `docs/testing.md`. Expect a trivial one-line conflict in `docs/testing.md`'s status section as siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)