### PR TITLE
test: add JVM unit tests for the six screen ViewModels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,11 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.serialization.core)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.okhttp.mockwebserver)
+    // ViewModel unit tests (SPEC section 9, unit level): reuse the same fakes/fixtures the
+    // instrumented UI integration tests use, so wire-format shapes never diverge between them.
+    testImplementation(testFixtures(project(":core-network")))
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4.accessibility)

--- a/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
@@ -8,7 +8,7 @@ package io.github.xexanos.ratatoskr.data
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
-import io.github.xexanos.ratatoskr.network.persist.TokenStore
+import io.github.xexanos.ratatoskr.network.persist.TokenAccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 class ConnectionManager(
     val connectionStore: ConnectionStore,
-    val tokenStore: TokenStore,
+    val tokenStore: TokenAccess,
 ) {
     // While a playback session is active the server owns refresh-token rotation, so the
     // client must not refresh independently (SPEC section 5).

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/auth/SignInViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/auth/SignInViewModelTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.xexanos.ratatoskr.ui.auth
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeTokenAccess
+import io.github.xexanos.ratatoskr.network.WireFixtures
+import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.mockwebserver.MockResponse
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SignInViewModelTest {
+
+    @get:Rule val server = HttpsMockServer()
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun connectionStore(): ConnectionStore {
+        val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { file }
+        return ConnectionStore(dataStore)
+    }
+
+    /** A [ConnectionManager] whose client() resolves against [server] (trusted server config saved). */
+    private fun trustedConnectionManager(): ConnectionManager {
+        val store = connectionStore()
+        runBlocking { store.saveTrustedServer(server.baseUrl, server.fingerprint) }
+        return ConnectionManager(store, FakeTokenAccess())
+    }
+
+    private fun unconfiguredConnectionManager(): ConnectionManager =
+        ConnectionManager(connectionStore(), FakeTokenAccess())
+
+    // signIn() only launches on viewModelScope and returns immediately; the actual login call
+    // runs on OkHttp's real thread pool independent of the Main test dispatcher, so the result
+    // lands asynchronously in real wall-clock time. Poll instead of asserting the very next line.
+    private fun waitUntil(timeoutMillis: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "condition not met within ${timeoutMillis}ms" }
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `blank username is a no-op`() = runTest(dispatcher) {
+        val viewModel = SignInViewModel(trustedConnectionManager())
+
+        viewModel.signIn("", "secret")
+
+        assertEquals(SignInUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `blank password is a no-op`() = runTest(dispatcher) {
+        val viewModel = SignInViewModel(trustedConnectionManager())
+
+        viewModel.signIn("alex", "")
+
+        assertEquals(SignInUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `a successful login moves to Success`() = runTest(dispatcher) {
+        server.enqueueJson(WireFixtures.authTokensJson())
+        val viewModel = SignInViewModel(trustedConnectionManager())
+
+        viewModel.signIn("alex", "secret")
+        waitUntil { viewModel.uiState.value != SignInUiState.Submitting }
+
+        assertEquals(SignInUiState.Success, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `a rejected login surfaces an error and does not report Success`() = runTest(dispatcher) {
+        server.server.enqueue(
+            MockResponse().setResponseCode(401).setBody("""{"code":"unauthorized","message":"no"}"""),
+        )
+        val viewModel = SignInViewModel(trustedConnectionManager())
+
+        viewModel.signIn("alex", "wrong")
+        waitUntil { viewModel.uiState.value != SignInUiState.Submitting }
+
+        val state = viewModel.uiState.value
+        assertTrue("expected Error, was $state", state is SignInUiState.Error)
+    }
+
+    @Test
+    fun `no configured server surfaces a specific error`() = runTest(dispatcher) {
+        val viewModel = SignInViewModel(unconfiguredConnectionManager())
+
+        viewModel.signIn("alex", "secret")
+        waitUntil { viewModel.uiState.value != SignInUiState.Submitting }
+
+        assertEquals(SignInUiState.Error("No server configured."), viewModel.uiState.value)
+    }
+}

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/connect/ConnectViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/connect/ConnectViewModelTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.xexanos.ratatoskr.ui.connect
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeTokenAccess
+import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import io.github.xexanos.ratatoskr.network.tls.CertificateInspector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ConnectViewModelTest {
+
+    @get:Rule val server = HttpsMockServer()
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun connectionStore(): ConnectionStore {
+        val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { file }
+        return ConnectionStore(dataStore)
+    }
+
+    private fun viewModel(store: ConnectionStore = connectionStore()) = ConnectViewModel(
+        inspector = CertificateInspector(),
+        connectionStore = store,
+        connectionManager = ConnectionManager(store, FakeTokenAccess()),
+    )
+
+    // inspect()/confirm() only launch on viewModelScope and return immediately; the certificate
+    // fetch runs on a real OkHttp thread pool (CertificateInspector explicitly hops to
+    // Dispatchers.IO) independent of the Main test dispatcher, so the result lands asynchronously
+    // in real wall-clock time. Poll instead of asserting the very next line.
+    private fun waitUntil(timeoutMillis: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "condition not met within ${timeoutMillis}ms" }
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `inspecting a blank URL is a no-op`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+
+        viewModel.inspect("   ")
+
+        assertEquals(ConnectUiState.Idle, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `inspecting a reachable server moves to Confirm with its certificate`() = runTest(dispatcher) {
+        server.enqueueJson("""{"reachable":true}""")
+        val viewModel = viewModel()
+
+        viewModel.inspect(server.baseUrl)
+        waitUntil { viewModel.uiState.value !is ConnectUiState.Inspecting }
+
+        val state = viewModel.uiState.value
+        assertTrue("expected Confirm, was $state", state is ConnectUiState.Confirm)
+        assertEquals(server.fingerprint, (state as ConnectUiState.Confirm).info.sha256Fingerprint)
+    }
+
+    @Test
+    fun `inspecting an unreachable server surfaces an error`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+
+        // Nothing listens on :1, so the TLS handshake itself fails.
+        viewModel.inspect("https://localhost:1")
+        waitUntil { viewModel.uiState.value !is ConnectUiState.Inspecting }
+
+        val state = viewModel.uiState.value
+        assertTrue("expected Error, was $state", state is ConnectUiState.Error)
+    }
+
+    @Test
+    fun `confirming a certificate saves it, invalidates the client cache, and moves to Trusted`() =
+        runTest(dispatcher) {
+            val store = connectionStore()
+            val viewModel = viewModel(store)
+
+            viewModel.confirm("https://ratatoskr.home:8080", "ab:cd:ef")
+            waitUntil { viewModel.uiState.value is ConnectUiState.Trusted }
+
+            assertEquals(ConnectUiState.Trusted, viewModel.uiState.value)
+            assertEquals("https://ratatoskr.home:8080", store.currentServerConfig()?.baseUrl)
+            assertEquals("ab:cd:ef", store.fingerprint())
+        }
+
+    @Test
+    fun `reset returns to Idle`() = runTest(dispatcher) {
+        val store = connectionStore()
+        val viewModel = viewModel(store)
+        viewModel.confirm("https://ratatoskr.home:8080", "ab:cd:ef")
+        waitUntil { viewModel.uiState.value is ConnectUiState.Trusted }
+
+        viewModel.reset()
+
+        assertEquals(ConnectUiState.Idle, viewModel.uiState.value)
+        // reset() only clears the screen's own state; it does not undo the persisted trust.
+        assertEquals("ab:cd:ef", store.fingerprint())
+    }
+}

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.xexanos.ratatoskr.ui.library
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeTokenAccess
+import io.github.xexanos.ratatoskr.network.WireFixtures
+import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.mockwebserver.MockResponse
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.Collections
+
+class LibraryViewModelTest {
+
+    @get:Rule val server = HttpsMockServer()
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    // Standard, not Unconfined: the debounce test drives virtual time explicitly to prove
+    // rapid keystrokes collapse into a single request instead of one per keystroke.
+    private val dispatcher = StandardTestDispatcher()
+
+    private val receivedQueries = Collections.synchronizedList(mutableListOf<String?>())
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        server.dispatch { request ->
+            val q = request.requestUrl?.queryParameter("q")
+            receivedQueries += q
+            MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))),
+                )
+        }
+    }
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun trustedConnectionManager(): ConnectionManager {
+        val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
+        // A real dispatcher, not the shared virtual `dispatcher`: this store is seeded via
+        // runBlocking below, before the virtual scheduler is ever pumped - sharing the virtual
+        // scheduler here would deadlock (nothing would ever advance it to service the write).
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(Dispatchers.IO)) { file }
+        val store = ConnectionStore(dataStore)
+        runBlocking { store.saveTrustedServer(server.baseUrl, server.fingerprint) }
+        return ConnectionManager(store, FakeTokenAccess())
+    }
+
+    // The debounce delay is virtual (driven by dispatcher.scheduler), but the actual HTTP round
+    // trip once debounce elapses is real (OkHttp's own thread pool) - and its result only gets
+    // applied to state once the resumed continuation is next pumped on the virtual scheduler.
+    // This alternates draining the virtual queue with a short real wait until `condition` holds.
+    private fun settleState(timeoutMillis: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (!condition()) {
+            dispatcher.scheduler.advanceUntilIdle()
+            if (condition()) return
+            check(System.currentTimeMillis() < deadline) { "condition not met within ${timeoutMillis}ms" }
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `initial load fetches the full library without a query`() = runTest(dispatcher) {
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        assertEquals(listOf(null), receivedQueries)
+        assertEquals(1, viewModel.uiState.value.items.size)
+    }
+
+    @Test
+    fun `rapid keystrokes are debounced into a single request for the final query`() = runTest(dispatcher) {
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() } // settle the initial (null) load
+
+        viewModel.search("cat")
+        dispatcher.scheduler.advanceTimeBy(100)
+        viewModel.search("dog")
+        dispatcher.scheduler.advanceTimeBy(100)
+        viewModel.search("fox")
+        dispatcher.scheduler.advanceTimeBy(299)
+
+        // Still within 300ms of the last keystroke: no new request fired yet.
+        assertEquals(listOf(null), receivedQueries)
+
+        dispatcher.scheduler.advanceTimeBy(2)
+        settleState { receivedQueries.size == 2 }
+
+        assertEquals(listOf(null, "fox"), receivedQueries)
+        settleState { viewModel.uiState.value.items.singleOrNull()?.title == "fox" }
+    }
+
+    @Test
+    fun `clearing the search box reissues the full library load`() = runTest(dispatcher) {
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        viewModel.search("cat")
+        settleState { receivedQueries.size == 2 }
+        viewModel.search("")
+        settleState { receivedQueries.size == 3 }
+
+        // A blank query debounces at 0ms, same as the initial load - it is not throttled like a
+        // real keystroke because there is nothing left to type past.
+        assertEquals(listOf(null, "cat", null), receivedQueries)
+    }
+
+    @Test
+    fun `no configured server surfaces a specific error`() = runTest(dispatcher) {
+        val store = ConnectionStore(
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) {
+                tempFolder.root.resolve("unconfigured_${System.nanoTime()}.preferences_pb")
+            },
+        )
+        val viewModel = LibraryViewModel(ConnectionManager(store, FakeTokenAccess()))
+
+        settleState { viewModel.uiState.value.error != null }
+
+        assertEquals("No server configured.", viewModel.uiState.value.error)
+        assertTrue(viewModel.uiState.value.items.isEmpty())
+    }
+
+    @Test
+    fun `a failing request surfaces the mapped error`() = runTest(dispatcher) {
+        server.dispatch {
+            MockResponse().setResponseCode(502)
+                .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+
+        settleState { viewModel.uiState.value.error != null }
+
+        assertEquals("Audiobookshelf down", viewModel.uiState.value.error)
+    }
+}

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingViewModelTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.xexanos.ratatoskr.ui.nowplaying
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeTokenAccess
+import io.github.xexanos.ratatoskr.network.WireFixtures
+import io.github.xexanos.ratatoskr.network.domain.PlaybackState
+import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.mockwebserver.MockResponse
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class NowPlayingViewModelTest {
+
+    @get:Rule val server = HttpsMockServer()
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    // A real, single confined thread - not UnconfinedTestDispatcher. pause()/stop() launch on
+    // viewModelScope and their network call completes on one of OkHttp's own worker threads;
+    // with an Unconfined dispatcher the ViewModel's state update would run inline on THAT OkHttp
+    // callback thread, which can end up being the very thread this test's own waitUntil() is
+    // blocking on. Confining Main to its own thread keeps ViewModel state mutation independent
+    // of whichever thread happens to deliver a given HTTP response.
+    private val mainThread = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(mainThread)
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        mainThread.close()
+    }
+
+    private fun jsonResponse(body: String, code: Int = 200) =
+        MockResponse().setResponseCode(code).setHeader("Content-Type", "application/json").setBody(body)
+
+    private fun trustedConnectionManager(): ConnectionManager {
+        val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(Dispatchers.IO)) { file }
+        val store = ConnectionStore(dataStore)
+        runBlocking { store.saveTrustedServer(server.baseUrl, server.fingerprint) }
+        return ConnectionManager(store, FakeTokenAccess())
+    }
+
+    // pause()/stop() only launch on viewModelScope and return immediately; poll instead of
+    // asserting the very next line.
+    private fun waitUntil(timeoutMillis: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "condition not met within ${timeoutMillis}ms" }
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `refresh populates the current session`() = runBlocking {
+        server.dispatch { jsonResponse(WireFixtures.sessionJson(state = "playing")) }
+        val viewModel = NowPlayingViewModel(trustedConnectionManager())
+
+        viewModel.refresh()
+
+        val state = viewModel.uiState.value
+        assertEquals(PlaybackState.PLAYING, state.session?.state)
+        assertEquals(false, state.loading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `refresh with no active session clears loading without an error`() = runBlocking {
+        server.dispatch {
+            jsonResponse("""{"code":"no_active_session","message":"Nothing playing"}""", code = 404)
+        }
+        val viewModel = NowPlayingViewModel(trustedConnectionManager())
+
+        viewModel.refresh()
+
+        val state = viewModel.uiState.value
+        assertNull(state.session)
+        assertEquals(false, state.loading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `refresh failure surfaces the mapped error`() = runBlocking {
+        server.dispatch {
+            jsonResponse("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""", code = 502)
+        }
+        val viewModel = NowPlayingViewModel(trustedConnectionManager())
+
+        viewModel.refresh()
+
+        assertEquals("Audiobookshelf down", viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `stop flips stopped and a subsequent refresh becomes a no-op`() = runBlocking {
+        val getRequests = AtomicInteger(0)
+        server.dispatch { request ->
+            when {
+                request.method == "DELETE" -> MockResponse().setResponseCode(204)
+                else -> {
+                    getRequests.incrementAndGet()
+                    jsonResponse(WireFixtures.sessionJson(state = "playing"))
+                }
+            }
+        }
+        val viewModel = NowPlayingViewModel(trustedConnectionManager())
+        viewModel.refresh()
+        assertEquals(1, getRequests.get())
+
+        viewModel.stop()
+        waitUntil { viewModel.uiState.value.stopped }
+
+        // A poll that would land after stop() must not even reach the server, let alone revive
+        // the session the user just ended (the `stopped` guard at the top of refresh()).
+        viewModel.refresh()
+        assertEquals(1, getRequests.get())
+    }
+
+    @Test
+    fun `a stale in-flight poll does not revert a newer control action`() = runBlocking {
+        val pollRequested = CountDownLatch(1)
+        val releasePoll = CountDownLatch(1)
+        server.dispatch { request ->
+            when {
+                request.method == "GET" -> {
+                    pollRequested.countDown()
+                    // Simulate a poll that was already in flight when the user paused: it only
+                    // resolves (with the now-stale "playing" state) after the pause has landed.
+                    releasePoll.await(5, TimeUnit.SECONDS)
+                    jsonResponse(WireFixtures.sessionJson(state = "playing"))
+                }
+                request.path.orEmpty().endsWith("/pause") -> jsonResponse(WireFixtures.sessionJson(state = "paused"))
+                else -> MockResponse().setResponseCode(404)
+            }
+        }
+        val viewModel = NowPlayingViewModel(trustedConnectionManager())
+
+        // Dispatchers.IO, not the default (this runBlocking's own confined thread): the very
+        // next line blocks that thread with a plain (non-suspending) CountDownLatch.await(), so
+        // a child coroutine sharing it would never get scheduled to even issue its request.
+        val pollJob = launch(Dispatchers.IO) { viewModel.refresh() }
+        assertTrue("poll never reached the server", pollRequested.await(5, TimeUnit.SECONDS))
+
+        viewModel.pause()
+        waitUntil { viewModel.uiState.value.session?.state == PlaybackState.PAUSED }
+
+        releasePoll.countDown()
+        pollJob.join()
+
+        // The poll's stale "playing" result must not overwrite the pause the user issued while
+        // it was in flight (the commandEpoch guard - see the kdoc on NowPlayingViewModel).
+        assertEquals(PlaybackState.PAUSED, viewModel.uiState.value.session?.state)
+    }
+}

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.xexanos.ratatoskr.ui.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeTokenAccess
+import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SettingsViewModelTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    // Unconfined, not Standard: these tests care about the end state after a suspend chain
+    // (store write -> connectionManager.invalidate() -> state update) completes, not about
+    // controlling interleaving, so eager execution avoids a manual advanceUntilIdle() per test.
+    // LibraryViewModel's debounce test (which DOES need to control virtual time) uses
+    // StandardTestDispatcher instead - see LibraryViewModelTest.
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    // Step 2 smoke test (see task brief / docs/testing.md): a real Jetpack DataStore-Preferences
+    // instance, pointed at a temp file, with no Context and no Robolectric. If this stops working
+    // on a future dependency bump every other test in this class silently loses its
+    // connectionStore coverage, so the round-trip is asserted directly here.
+    @Test
+    fun `ConnectionStore round-trips a trusted server through a real DataStore on the JVM`() = runTest(dispatcher) {
+        val store = connectionStore()
+
+        store.saveTrustedServer("https://ratatoskr.home:8080", "ab:cd:ef")
+
+        assertEquals("https://ratatoskr.home:8080", store.currentServerConfig()?.baseUrl)
+        assertEquals("ab:cd:ef", store.fingerprint())
+    }
+
+    @Test
+    fun `initial state reports no configured server`() = runTest(dispatcher) {
+        val viewModel = SettingsViewModel(connectionManager())
+
+        assertNull(viewModel.uiState.value.serverUrl)
+    }
+
+    @Test
+    fun `initial state reports the trusted server's URL`() = runTest(dispatcher) {
+        val store = connectionStore()
+        store.saveTrustedServer("https://ratatoskr.home:8080", "ab:cd:ef")
+
+        val viewModel = SettingsViewModel(connectionManager(store))
+
+        assertEquals("https://ratatoskr.home:8080", viewModel.uiState.value.serverUrl)
+    }
+
+    @Test
+    fun `forgetCertificate drops the fingerprint and flips certForgotten`() = runTest(dispatcher) {
+        val store = connectionStore()
+        store.saveTrustedServer("https://ratatoskr.home:8080", "ab:cd:ef")
+        val viewModel = SettingsViewModel(connectionManager(store))
+
+        viewModel.forgetCertificate()
+
+        assertTrue(viewModel.uiState.value.certForgotten)
+        assertNull(store.fingerprint())
+        // The URL is kept for convenience (re-trust flow); only the fingerprint is forgotten.
+        assertEquals("https://ratatoskr.home:8080", store.currentServerConfig()?.baseUrl)
+    }
+
+    @Test
+    fun `signOut clears the token store and flips signedOut`() = runTest(dispatcher) {
+        val tokens = FakeTokenAccess(accessToken = "a1", refreshToken = "r1")
+        val viewModel = SettingsViewModel(connectionManager(tokenStore = tokens))
+
+        viewModel.signOut()
+
+        assertTrue(viewModel.uiState.value.signedOut)
+        assertNull(tokens.currentAccessTokenBlocking())
+    }
+
+    private fun connectionStore(): ConnectionStore {
+        val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { file }
+        return ConnectionStore(dataStore)
+    }
+
+    private fun connectionManager(
+        connectionStore: ConnectionStore = connectionStore(),
+        tokenStore: FakeTokenAccess = FakeTokenAccess(),
+    ) = ConnectionManager(connectionStore, tokenStore)
+}

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/speakers/SpeakersViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/speakers/SpeakersViewModelTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package io.github.xexanos.ratatoskr.ui.speakers
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeTokenAccess
+import io.github.xexanos.ratatoskr.network.WireFixtures
+import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.mockwebserver.MockResponse
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SpeakersViewModelTest {
+
+    @get:Rule val server = HttpsMockServer()
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun jsonResponse(body: String, code: Int = 200) =
+        MockResponse().setResponseCode(code).setHeader("Content-Type", "application/json").setBody(body)
+
+    private fun trustedConnectionManager(): ConnectionManager {
+        val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { file }
+        val store = ConnectionStore(dataStore)
+        runBlocking { store.saveTrustedServer(server.baseUrl, server.fingerprint) }
+        return ConnectionManager(store, FakeTokenAccess())
+    }
+
+    private fun unconfiguredConnectionManager(): ConnectionManager {
+        val file = tempFolder.root.resolve("unconfigured_${System.nanoTime()}.preferences_pb")
+        val dataStore: DataStore<Preferences> =
+            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { file }
+        return ConnectionManager(ConnectionStore(dataStore), FakeTokenAccess())
+    }
+
+    // loadSpeakers()/start() only launch on viewModelScope and return immediately; the actual
+    // HTTP call runs on OkHttp's real thread pool independent of the Main test dispatcher, so
+    // the result lands asynchronously in real wall-clock time. Poll instead of asserting the
+    // very next line.
+    private fun waitUntil(timeoutMillis: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "condition not met within ${timeoutMillis}ms" }
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `initial load fetches the speaker list`() = runTest(dispatcher) {
+        server.dispatch { jsonResponse(WireFixtures.speakerListJson()) }
+
+        val viewModel = SpeakersViewModel(trustedConnectionManager(), itemId = "i1")
+        waitUntil { !viewModel.uiState.value.loading }
+
+        val state = viewModel.uiState.value
+        assertFalse(state.loading)
+        assertEquals(1, state.speakers.size)
+    }
+
+    @Test
+    fun `no configured server surfaces a specific error`() = runTest(dispatcher) {
+        val viewModel = SpeakersViewModel(unconfiguredConnectionManager(), itemId = "i1")
+        waitUntil { !viewModel.uiState.value.loading }
+
+        val state = viewModel.uiState.value
+        assertFalse(state.loading)
+        assertEquals("No server configured.", state.error)
+    }
+
+    @Test
+    fun `a failing request surfaces the mapped error`() = runTest(dispatcher) {
+        server.dispatch {
+            MockResponse().setResponseCode(401).setBody("""{"code":"unauthorized","message":"no"}""")
+        }
+
+        val viewModel = SpeakersViewModel(trustedConnectionManager(), itemId = "i1")
+        waitUntil { !viewModel.uiState.value.loading }
+
+        assertEquals("Sign-in expired. Please sign in again.", viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `starting a session on a speaker moves to started`() = runTest(dispatcher) {
+        server.dispatch { request ->
+            when {
+                request.path.orEmpty().startsWith("/v1/speakers") -> jsonResponse(WireFixtures.speakerListJson())
+                request.path.orEmpty().startsWith("/v1/sessions/current") && request.method == "PUT" ->
+                    jsonResponse(WireFixtures.sessionJson())
+                else -> MockResponse().setResponseCode(404)
+            }
+        }
+        val viewModel = SpeakersViewModel(trustedConnectionManager(), itemId = "i1")
+        waitUntil { !viewModel.uiState.value.loading }
+
+        viewModel.start("s1")
+        waitUntil { !viewModel.uiState.value.starting }
+
+        val state = viewModel.uiState.value
+        assertTrue(state.started)
+        assertFalse(state.starting)
+    }
+
+    @Test
+    fun `a failing start surfaces an error and stops starting`() = runTest(dispatcher) {
+        server.dispatch { request ->
+            when {
+                request.path.orEmpty().startsWith("/v1/speakers") -> jsonResponse(WireFixtures.speakerListJson())
+                request.path.orEmpty().startsWith("/v1/sessions/current") && request.method == "PUT" ->
+                    MockResponse().setResponseCode(502).setBody(
+                        """{"code":"abs_unreachable","message":"Audiobookshelf down"}""",
+                    )
+                else -> MockResponse().setResponseCode(404)
+            }
+        }
+        val viewModel = SpeakersViewModel(trustedConnectionManager(), itemId = "i1")
+        waitUntil { !viewModel.uiState.value.loading }
+
+        viewModel.start("s1")
+        waitUntil { !viewModel.uiState.value.starting }
+
+        val state = viewModel.uiState.value
+        assertFalse(state.starting)
+        assertFalse(state.started)
+        assertEquals("Audiobookshelf down", state.error)
+    }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,7 +66,9 @@ black-box. See the central concept's open points.
 
 The strategy above is the target. Current state:
 
-- **Present:** `core-network` unit tests (JUnit4 + MockWebServer); instrumented
+- **Present:** `core-network` unit tests (JUnit4 + MockWebServer); per-screen
+  ViewModel state-transition unit tests (`:app`, JUnit4, against a real
+  `ConnectionStore`/DataStore on the JVM and `HttpsMockServer`); instrumented
   component tests (auth, deserialization, error mapping, session rotation, TLS
   pinning); accessibility checks across every screen (ATF, WARNING threshold incl.
   contrast) in the emulator's default theme.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref 
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 moshi-adapters = { group = "com.squareup.moshi", name = "moshi-adapters", version.ref = "moshi" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 jts-core = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts" }
 


### PR DESCRIPTION
`docs/testing.md` lists per-screen ViewModel state transitions as unit-level coverage, but there were zero — `app/src/test/` held only the default `ExampleUnitTest`. The blocker was that `ConnectionManager` took the concrete, Keystore-bound `TokenStore`, so it couldn't be built on plain JVM.

**Seam** (`refactor` commit): `ConnectionManager` now depends on the existing `TokenAccess` interface instead of the concrete `TokenStore`. All call sites (`AppContainer`, `SettingsViewModel`) stay source-compatible; tests can now build a real `ConnectionManager` with the shared `FakeTokenAccess` fixture.

**Tests** (`test` commit): 30 tests, 5 per ViewModel (Connect, SignIn, Library, Speakers, NowPlaying, Settings), focused on ViewModel-only logic not already covered by `AppFlowTest` — e.g. Library search debounce/`collectLatest`, NowPlaying's `commandEpoch` stale-poll guard, SignIn blank-input validation, null-client error states. They reuse the `HttpsMockServer`/`WireFixtures` test fixtures the instrumented suite uses, so wire shapes never diverge.

Build wiring: `testImplementation` of `kotlinx-coroutines-test`, `okhttp-mockwebserver`, and `testFixtures(:core-network)`; a `kotlinx-coroutines-test` catalog alias.

## Verification
- `:app:testDebugUnitTest` + `:core-network:testDebugUnitTest` green, run 3× with `--rerun`, no flakiness.
- No regression from the seam: `:core-network:connectedDebugAndroidTest` 20/20, `AppFlowTest` 7/7.

## Known gap (flagged, not hidden)
No dedicated test for a slow in-flight Library search being cancelled by `collectLatest` when a second already-debounced query arrives — that's timing-dependent on real network completion under a virtual dispatcher and risked flakiness. The debounce-collapse case (the practically important one) is covered.

## Part of a batch
One of five small PRs aligning the codebase with `docs/testing.md`. Expect a trivial one-line conflict in `docs/testing.md`'s status section as siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)