### PR TITLE
fix(build): R8 on the minified test APK + per-PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,13 @@ jobs:
         run: bash scripts/check-ux.sh
 
       - name: Lint, assemble debug and run unit tests
-        # assembleRelease AND assembleMinified both run R8 (SPEC section 8) on the JVM, so a
-        # broken keep rule or shrinker config fails the PR cheaply here. assembleMinified is
-        # what parses the minified-only src/minified/keepRules/tests.keep - assembleRelease
-        # sees src/main/keepRules only - so without it a typo'd test keep rule would slip
-        # through PR CI and only surface post-merge. The on-device validation of the shrunk
-        # build still runs post-merge (release-validation.yml).
-        run: ./gradlew --no-daemon lintDebug testDebugUnitTest assembleDebug :app:assembleRelease :app:assembleMinified
+        run: ./gradlew --no-daemon lintDebug testDebugUnitTest assembleDebug :app:assembleRelease
+
+      - name: Run R8 on the minified app + instrumented-test APKs (JVM, no emulator)
+        # assembleMinifiedAndroidTest runs R8 on BOTH the minified app APK
+        # (minifyMinifiedWithR8) and the instrumented-test APK (minifyMinifiedAndroidTestWithR8).
+        # The latter is the one assembleMinified alone never builds, so a missing-class / keep
+        # rule error in the test APK's R8 (e.g. test-only deps referencing compile-time-only
+        # classes) is caught here per PR instead of only in release-validation.yml post-merge.
+        # -PminifiedTests switches testBuildType to `minified` so the task exists.
+        run: ./gradlew --no-daemon -PminifiedTests :app:assembleMinifiedAndroidTest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,12 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is
+        // minified (the `minified` build type, -PminifiedTests); the default debug test APK is
+        // not shrunk. They -dontwarn the compile-time-only classes that test-only deps
+        // (okhttp-tls, mockwebserver, espresso-accessibility) reference but that are absent at
+        // runtime, which R8 would otherwise reject in minifyMinifiedAndroidTestWithR8.
+        testProguardFiles("proguard-test-rules.pro")
     }
 
     buildTypes {

--- a/app/proguard-test-rules.pro
+++ b/app/proguard-test-rules.pro
@@ -1,0 +1,12 @@
+# R8 rules for the instrumented-test APK only (testProguardFiles). Effective solely when the
+# androidTest APK is itself minified - i.e. the `minified` build type via -PminifiedTests
+# (see app/build.gradle.kts); ignored for the default debug test APK, which is not shrunk.
+#
+# The test APK pulls in test-only dependencies (okhttp-tls, mockwebserver, the Espresso
+# accessibility integration) that reference compile-time / annotation-processor classes which
+# are absent at runtime. R8 treats those as missing-class errors and aborts
+# (minifyMinifiedAndroidTestWithR8). They are safe to ignore - none are reachable at runtime.
+# These mirror the rules AGP emits in build/outputs/mapping/minifiedAndroidTest/missing_rules.txt.
+-dontwarn org.codehaus.mojo.animal_sniffer.**
+-dontwarn com.google.auto.value.**
+-dontwarn javax.lang.model.**


### PR DESCRIPTION
## Problem

The first post-merge `Release validation` run on `main` failed at `:app:minifyMinifiedAndroidTestWithR8` ([run 29191869854](https://github.com/Xexanos/ratatoskr-app/actions/runs/29191869854)). R8 on the **instrumented-test** APK aborts on missing compile-time-only classes referenced by test-only dependencies but absent at runtime:

- `org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement` ← okhttp-tls
- `com.google.auto.value.AutoValue` / `$Builder` ← espresso-accessibility
- `javax.lang.model.element.Modifier` ← errorprone annotations

This is not an emulator/infra issue and not the app APK's R8 (that passed). It surfaced only post-merge because the per-PR gate built `:app:assembleMinified` (app APK R8) but never the test APK's R8.

## Fix

1. **`testProguardFiles(proguard-test-rules.pro)`** with `-dontwarn` for those compile-time-only classes. Effective only when the androidTest APK is minified (the `minified` build type, `-PminifiedTests`); the default debug test APK is unaffected. Mirrors the rules AGP emits in `missing_rules.txt`.
2. **Close the gate gap:** `ci.yml` now runs `:app:assembleMinifiedAndroidTest`, which runs R8 on **both** the app APK (`minifyMinifiedWithR8`) and the test APK (`minifyMinifiedAndroidTestWithR8`), JVM-only. This class of failure is now caught per PR.

## Verification

Ran locally (the task that failed on CI):

```
./gradlew -PminifiedTests :app:assembleMinifiedAndroidTest
> Task :app:minifyMinifiedAndroidTestWithR8
> Task :app:packageMinifiedAndroidTest
BUILD SUCCESSFUL
```

CI on this PR now exercises the same task; `release-validation.yml` on the next merge to main should get past this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)