### PR TITLE
fix(build): make the minified on-device validation actually run - and gate it per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,7 @@ jobs:
         # rule error in the test APK's R8 (e.g. test-only deps referencing compile-time-only
         # classes) is caught here per PR instead of only in release-validation.yml post-merge.
         # -PminifiedTests switches testBuildType to `minified` so the task exists.
+        # This JVM run only proves the R8 *config* is sound; runtime resolution gaps (classes
+        # the test APK resolves from the shrunk app APK only at runtime) are invisible here
+        # and are covered per PR by test-minified-smoke in instrumented-tests.yml.
         run: ./gradlew --no-daemon -PminifiedTests :app:assembleMinifiedAndroidTest

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -12,6 +12,9 @@
 #     accessibility stack: adb goes "offline" and the job hangs to its timeout, and the
 #     accessibility service is often not live (the ATF canary test catches exactly that).
 #     These suites exercise no API-26-specific behaviour, so API 36 is the meaningful target.
+#   - the minified wire smoke (MinifiedWireSmokeTest against the R8-shrunk `minified`
+#     variant) runs on API 36 only, for the same reason. It exists because the JVM R8 gate
+#     in ci.yml cannot see runtime resolution gaps (SPEC section 8) - see its job comment.
 #
 # Two-stage design:
 #   1. `warm-avd` boots one emulator per API level (on a cache miss only) purely to populate
@@ -258,6 +261,86 @@ jobs:
             app/build/outputs/androidTest-results/connected
             core-network/build/reports/androidTests/connected
             core-network/build/outputs/androidTest-results/connected
+          retention-days: 14
+
+  # Minified wire smoke: API 36 only (see header). Runs MinifiedWireSmokeTest against the
+  # R8-shrunk `minified` variant (-PminifiedTests). The JVM gate in ci.yml
+  # (assembleMinifiedAndroidTest) proves the keep rules parse and R8's reference tracing
+  # passes, but only an on-device run catches *runtime* gaps: classes the androidTest APK
+  # expects to resolve from the shrunk app APK (AGP filters app-provided dependencies out
+  # of the test APK), and members reached only reflectively. Both bit main before this job
+  # existed - a kotlin.LazyKt NoClassDefFoundError at instrumentation start, and Moshi's
+  # reflective defaults-constructor lookup (NoSuchMethodException). The full AppFlowTest
+  # against minified stays post-merge in release-validation.yml (SPEC section 8): its
+  # failure modes overlap heavily with this smoke, so per PR the short suite buys almost
+  # all the signal at a fraction of the cost.
+  test-minified-smoke:
+    needs: warm-avd
+    runs-on: ubuntu-latest
+    # The two R8 runs (app + test APK) make the build a few minutes slower than the
+    # debug-variant jobs; the suite itself is seconds.
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [36]
+
+    steps:
+      - name: Check out (with the contract submodule)
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Enable KVM for the emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Restore the warmed AVD snapshot
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
+
+      - name: Run the wire smoke against the minified build
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          target: default
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          # See test-component: reap orphaned crashpad_handler on the trailing lines so
+          # the emulator teardown can't hang the job (android-emulator-runner#385).
+          script: |
+            ./gradlew -PminifiedTests :app:connectedMinifiedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.github.xexanos.ratatoskr.ui.MinifiedWireSmokeTest
+            pkill -f -SIGTERM '[c]rashpad_handler' || true
+            sleep 5
+            pkill -f -SIGKILL '[c]rashpad_handler' || true
+
+      - name: Upload the test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-reports-minified-smoke-api${{ matrix.api-level }}
+          path: |
+            app/build/reports/androidTests/connected
+            app/build/outputs/androidTest-results/connected
           retention-days: 14
 
   # Accessibility, light mode: API 36 only (see header).

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,8 +17,11 @@
 # retention window below, so the per-commit releases do not accumulate forever.
 #
 # This runs post-merge rather than per PR (a deliberate cost trade-off; the per-PR gate is
-# assembleRelease + assembleMinified in ci.yml, which catch R8 config / keep-rule errors on
-# the JVM). paths-ignore is the same docs/metadata denylist the other workflows use.
+# assembleRelease + assembleMinifiedAndroidTest in ci.yml for R8 config / keep-rule errors
+# on the JVM, plus the on-device test-minified-smoke job in instrumented-tests.yml for the
+# runtime resolution gaps a JVM build cannot see - only the full AppFlowTest against the
+# shrunk build waits for post-merge). paths-ignore is the same docs/metadata denylist the
+# other workflows use.
 
 name: Release validation
 

--- a/app/src/main/keepRules/rules.keep
+++ b/app/src/main/keepRules/rules.keep
@@ -24,3 +24,17 @@
     <init>(com.squareup.moshi.Moshi);
     <init>(com.squareup.moshi.Moshi, java.lang.reflect.Type[]);
 }
+
+# The adapters also reach into the models reflectively: when a JSON payload omits a
+# property that has a Kotlin default value, the generated adapter looks up the model's
+# synthetic "defaults" constructor (<init>(..., int mask, DefaultConstructorMarker)) via
+# Class.getDeclaredConstructor (Moshi's Util.lookupDefaultsConstructor). R8 cannot trace
+# that, strips the constructor, and deserialization fails with NoSuchMethodException -
+# caught on-device by MinifiedWireSmokeTest. moshi-kotlin-codegen generates this exact
+# per-model rule too (same META-INF/proguard mechanism as the adapter keeps above), and
+# the on-device failure proved those resource-borne rules really do NOT propagate from
+# core-network into this module's R8 run - so this insurance is load-bearing, not
+# belt-and-braces. Generic member shape mirroring the generated per-model rules.
+-keepclassmembers class io.github.xexanos.ratatoskr.network.generated.model.** {
+    public synthetic <init>(...);
+}

--- a/app/src/minified/keepRules/tests.keep
+++ b/app/src/minified/keepRules/tests.keep
@@ -9,3 +9,35 @@
 -keep class io.github.xexanos.ratatoskr.di.AppContainer { *; }
 -keep class io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory { *; }
 -keep class io.github.xexanos.ratatoskr.network.api.RatatoskrClient { *; }
+
+# Shared libraries the instrumented-test APK resolves from the APP APK. AGP filters
+# every dependency that is already on the tested app's runtime classpath out of the
+# androidTest APK, so at runtime the test process loads those classes from the app.
+# The release-shape shrinker only retains what app code reaches; what only the test
+# frameworks need would be gone - the instrumentation then crashes at startup
+# (NoClassDefFoundError: kotlin.LazyKt from androidx.test's OutputDirCalculator; the
+# same pattern follows for espresso's androidx.core view helpers, compose-ui-test's
+# compose internals, mockwebserver's okhttp internals). AGP has no test-aware keep
+# generation (issuetracker.google.com/126429384; Slack's Keeper plugin predates AGP 9),
+# so keep these libraries wholesale - class-granular rules would be whack-a-mole with
+# every test or dependency change.
+#
+# Deliberate trade-off (SPEC section 8): only in this debug-signed validation variant,
+# the release APK keeps its minimal rules. Shrinking of the app's own code, the
+# generated client, and everything NOT listed here (retrofit2, moshi, androidx.navigation,
+# compose material3/foundation/animation and the material-icons vectors) still matches
+# release exactly - the surfaces the validation exists to prove stay proven. Compose is
+# deliberately only ui + runtime (what compose-ui-test itself reaches); widening it to
+# androidx.compose.** would exempt all of compose from validation and balloon the
+# published validation APK with the kept material-icons-extended vectors.
+-keep class kotlin.** { *; }
+-keep class kotlinx.coroutines.** { *; }
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }
+-keep class androidx.core.** { *; }
+-keep class androidx.compose.ui.** { *; }
+-keep class androidx.compose.runtime.** { *; }
+-keep class androidx.activity.** { *; }
+-keep class androidx.lifecycle.** { *; }
+-keep class androidx.concurrent.futures.** { *; }
+-keep class com.google.common.util.concurrent.** { *; }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -191,9 +191,25 @@ screen exposes the server URL, a re-trust/forget action for the certificate, and
     adapter — and no `kotlin-reflect` — ships at all. Enums keep Moshi's built-in handling,
     so the unknown-`PlaybackState` fallback (section 4) is unaffected.
   - Keep rules are deliberately minimal: the libraries' own consumer rules (Retrofit, OkHttp,
-    Moshi) plus the per-model adapter keeps moshi-kotlin-codegen generates, mirrored
-    explicitly in `app/src/main/keepRules/rules.keep` as insurance in case the library-module
-    resource rules do not propagate.
+    Moshi) plus the rules moshi-kotlin-codegen generates per model — the adapter keeps *and*
+    the models' synthetic defaults constructors, which the adapters look up reflectively when
+    a payload omits a property with a default value. Both are mirrored explicitly in
+    `app/src/main/keepRules/rules.keep`, and that mirror is **load-bearing, not insurance**:
+    the on-device validation proved the codegen's resource-borne rules do not propagate from
+    `core-network` into the app's R8 run (the stripped defaults constructor failed
+    `MinifiedWireSmokeTest` with `NoSuchMethodException` — a real release-APK bug).
+  - The `minified` variant (below) additionally keeps, wholesale, the shared libraries the
+    instrumented-test APK resolves from the app APK (`app/src/minified/keepRules/tests.keep`):
+    AGP filters every dependency the app already ships out of the androidTest APK, so the test
+    frameworks' own needs — kotlin stdlib facades for androidx.test, espresso's androidx.core
+    view helpers, compose-ui-test's compose ui/runtime internals, mockwebserver's okhttp
+    internals — must survive the app-side shrinker or instrumentation crashes at startup
+    (AGP has no test-aware keep generation: issuetracker.google.com/126429384; Slack's Keeper
+    plugin predates AGP 9 and is unmaintained). This is a documented deviation of the
+    validation variant only: the release APK keeps its minimal rules, and everything the
+    validation exists to prove — the app's own code, the generated client, retrofit2/moshi,
+    androidx.navigation, compose material3/foundation and the icon vectors — still shrinks
+    exactly as in release.
   - **No obfuscation** (`-dontobfuscate`): shrinking and optimization stay fully active, but
     names are kept readable. F-Droid users never receive a mapping file, so crash reports
     must stay legible; unobfuscated output is also easier to verify for the reproducible
@@ -205,9 +221,15 @@ screen exposes the server URL, a re-trust/forget action for the certificate, and
     flow plus a wire-level smoke mirror against it. On success the workflow publishes the
     tested APKs to a per-commit `testing-<short-sha>` pre-release (pruned by a scheduled
     cleanup job) and (once the `ratatoskr-e2e` repository exists) triggers the cross-component
-    E2E suite. The per-PR gate is `assembleRelease` **and** `assembleMinified` in CI, which
-    catch keep-rule/shrinker config errors cheaply on the JVM without an emulator —
-    `assembleMinified` is what parses the minified-only keep rules.
+    E2E suite. The per-PR gate is layered: `assembleRelease` and
+    `assembleMinifiedAndroidTest` in CI catch keep-rule/shrinker *config* errors cheaply on
+    the JVM without an emulator (the latter runs R8 on both the minified app APK and the
+    instrumented-test APK), and `MinifiedWireSmokeTest` runs on-device against the minified
+    variant in the instrumented-tests workflow, because a JVM build cannot see *runtime*
+    resolution gaps — a keep-rule set that builds cleanly can still leave the test process
+    unable to start (both post-merge failures that preceded this gate were of that class).
+    The full integration flow against the shrunk build stays post-merge: a deliberate cost
+    split, since its failure modes overlap heavily with the wire smoke.
   - Measured impact (unsigned release APK, CI): **13.3 MB** unshrunk → **2.2 MB** with code
     shrinking → **1.8 MB** with code + resource shrinking. Code shrinking accounts for the bulk
     (it strips `kotlin-reflect` and the unused `material-icons-extended` vectors, which are
@@ -299,7 +321,9 @@ the tested APKs to a per-commit `testing-<short-sha>` pre-release. `MinifiedWire
 never execute against shrunk output; it re-drives just the wire-level behaviours most exposed
 to R8 — the reflectively looked-up Moshi codegen adapters and the unknown-enum fallback —
 through the real factory. This is the same deliberate, thin overlap policy as above, extended
-to the minified context.
+to the minified context. `MinifiedWireSmokeTest` also runs per PR against the minified
+variant on an API 36 emulator (instrumented-tests workflow), so runtime R8 breakage — which
+the JVM assembly gate cannot see — is caught before merge, not only post-merge (section 8).
 
 ## 10. Definition of done for v1
 


### PR DESCRIPTION
## Why

`release-validation.yml` has never been green: the minified androidTest run crashed at instrumentation start with `NoClassDefFoundError: kotlin.LazyKt` (run 29192681752). Root-causing it on a local emulator surfaced **two independent bugs**, one of which affects the release APK itself.

## What was actually wrong

**1. The test APK resolves shared libraries from the app APK - and R8 had shrunk them away (validation-only).**
AGP filters every dependency the app already ships out of the androidTest APK, so at runtime the test process loads kotlin-stdlib, okhttp, androidx.core, compose-ui etc. from the app APK. The release-shape shrinker keeps only what *app code* reaches; `androidx.test`'s own `OutputDirCalculator` then dies on the stripped `kotlin.LazyKt` facade before any test starts. Confirmed by dex inspection: the test APK defines no stdlib at all, the shrunk app APK lacked the facade classes.
This also settles option (a) from the analysis: *not* minifying the test APK cannot fix this - the classes are missing at the dependency-packaging level, not because of the test APK's R8 run. AGP has no test-aware keep generation ([126429384](https://issuetracker.google.com/issues/126429384)); Slack's [Keeper](https://slackhq.github.io/keeper/) is unmaintained and predates AGP 9. So `tests.keep` (minified variant only) now keeps the shared libraries wholesale instead of class-by-class whack-a-mole. Compose is deliberately narrowed to `ui` + `runtime`: material3/foundation/animation and the material-icons vectors stay release-shrunk, keeping the validation surfaces honest and the published validation APK at 9.5 MB instead of 20 MB.

**2. A real release-APK bug: Moshi codegen looks up the models synthetic defaults constructors reflectively, and R8 stripped them.**
Once the runner could start, `MinifiedWireSmokeTest` failed with `NoSuchMethodException: ...model.Session.<init>` - exactly the failure class this validation exists to catch. moshi-kotlin-codegen *generates* the needed per-model rule, but the on-device run proved those `META-INF/proguard` rules do **not** propagate from `core-network` into the app R8 run. The mirror in `rules.keep` (which already covered the adapters) now also keeps the synthetic defaults constructors - it is load-bearing, not insurance. Without it, the release APK fails to deserialize any payload that omits a property with a default value. The AppFlowTest timeouts had the same root cause (sign-in flow could not deserialize the session).

**3. Per-PR gate (second commit, workflow files):** the JVM `assembleMinifiedAndroidTest` gate cannot see either failure class. New `test-minified-smoke` job in `instrumented-tests.yml` runs `MinifiedWireSmokeTest` against the minified variant on the warmed API 36 AVD per PR; the full `AppFlowTest` against the shrunk build stays post-merge (deliberate cost split, recorded in SPEC section 8).

## Verification

- 5 consecutive green local runs of the exact release-validation command (`-PminifiedTests :app:connectedMinifiedAndroidTest` with `AppFlowTest,MinifiedWireSmokeTest`) on an API 36 emulator (10/10 tests each).
- Dex-level confirmation that the previously missing classes are back in the minified app APK.
- `assembleRelease` builds; unsigned release APK stays at 1.72 MB (SPEC figure unchanged).
- All workflow YAML parses.

On merge, release-validation on main should go green and publish the first `testing-<sha>` pre-release, unblocking the E2E harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)