### PR TITLE
fix(build): keep androidx.collection in the minified test variant

### DIFF
--- a/app/src/minified/keepRules/tests.keep
+++ b/app/src/minified/keepRules/tests.keep
@@ -17,7 +17,9 @@
 # frameworks need would be gone - the instrumentation then crashes at startup
 # (NoClassDefFoundError: kotlin.LazyKt from androidx.test's OutputDirCalculator; the
 # same pattern follows for espresso's androidx.core view helpers, compose-ui-test's
-# compose internals, mockwebserver's okhttp internals). AGP has no test-aware keep
+# compose internals, mockwebserver's okhttp internals, and compose-ui-test's use of
+# androidx.collection - e.g. IntSetKt.intSetOf(vararg), which no app code reaches so R8
+# strips it from the app APK, giving NoSuchMethodError in the test process). AGP has no test-aware keep
 # generation (issuetracker.google.com/126429384; Slack's Keeper plugin predates AGP 9),
 # so keep these libraries wholesale - class-granular rules would be whack-a-mole with
 # every test or dependency change.
@@ -35,6 +37,7 @@
 -keep class okhttp3.** { *; }
 -keep class okio.** { *; }
 -keep class androidx.core.** { *; }
+-keep class androidx.collection.** { *; }
 -keep class androidx.compose.ui.** { *; }
 -keep class androidx.compose.runtime.** { *; }
 -keep class androidx.activity.** { *; }


### PR DESCRIPTION
## Problem

Release-validation broke on the merge of #31 (androidx bump: compose-BOM `2026.02.01 → 2026.06.01`, Kotlin `2.2.10 → 2.4.0`, `androidx.collection → 1.5.0`). The `connectedMinifiedAndroidTest` step crashed:

```
java.lang.NoSuchMethodError: No static method intSetOf([I)Landroidx/collection/IntSet;
  in class Landroidx/collection/IntSetKt; ... appears in ...base.apk
```

plus a follow-on `NoClassDefFoundError` on `androidx.compose.ui.test.AndroidInputDispatcher_androidKt` (cascade — that class's `<clinit>` calls `intSetOf`).

Validation was green on #30 (retrofit) and failed first on #31.

## Root cause

Same test-APK dependency-filter mechanism as #22, one library further out:

1. The new `compose-ui-test` calls `androidx.collection.intSetOf(vararg)`. No app code reaches that overload.
2. `androidx.collection` was **not** in `app/src/minified/keepRules/tests.keep`, so R8 stripped `intSetOf([I)` from the app APK. (Confirmed via `dexdump`: the shrunk `IntSetKt` retained only `<clinit>`, `getEmptyIntArray`, `mutableIntSetOf`.)
3. AGP filters `androidx.collection` out of the test APK (it's already on the app runtime classpath), so the test process loads the stripped `IntSetKt` from the app APK → `NoSuchMethodError`.

## Fix

Add a wholesale keep for `androidx.collection` to the **minified-only** keep rules, matching the existing per-library keeps. The real release APK is unaffected — this file only applies to the debug-signed `minified` validation variant.

```
-keep class androidx.collection.** { *; }
```

## Verification

- `dexdump` on the rebuilt minified APK confirms all five `intSetOf` overloads (incl. `([I)`) are back.
- Ran the exact CI command on the local emulator:
  `./gradlew -PminifiedTests :app:connectedMinifiedAndroidTest -P…class=AppFlowTest,MinifiedWireSmokeTest` → **10/10 passed**. No other strips surfaced from the bump.

## Note (out of scope)

The `ci.yml` run on the same merge commit failed separately at `:app:packageDebug` (`IncrementalSplitterRunnable`), which is unrelated to R8 keep rules and looks like a packaging flake. Not addressed here — worth a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)