### PR TITLE
fix(tls): ignore certificate hostname on the pinned connection

### DIFF
--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
@@ -28,6 +28,9 @@ import org.junit.runner.RunWith
  * skipped) is deliberately NOT covered here: the trust manager consults only the system trust
  * store, which a test-minted CA is not in, so a self-signed MockWebServer cannot reach that path.
  * It stays a documented gap (SPEC section 9).
+ *
+ * The fixture's certificate SAN deliberately does not match the host it serves on, so these
+ * tests also prove the pinned client ignores the certificate hostname (SPEC sections 6 and 14).
  */
 @RunWith(AndroidJUnit4::class)
 class FactoryTlsPinComponentTest {
@@ -45,6 +48,20 @@ class FactoryTlsPinComponentTest {
 
         assertTrue("expected Success, was $result", result is ApiResult.Success)
         assertTrue((result as ApiResult.Success).data.isEmpty())
+    }
+
+    @Test
+    fun aPinnedConnectionIgnoresTheCertificateHostname() = runBlocking {
+        // HttpsMockServer serves a certificate whose SAN never matches the loopback host it runs
+        // on, yet the connection succeeds: exact-cert pinning supersedes hostname verification,
+        // which the factory disables (SPEC sections 6 and 14). Guards against re-enabling the
+        // default hostname verifier on the pinned client - which would break connecting to a
+        // server by a LAN IP (and the E2E emulator's 10.0.2.2).
+        https.enqueueJson("[]")
+
+        val result = client(https.fingerprint).listSpeakers()
+
+        assertTrue("expected Success despite a non-matching cert SAN, was $result", result is ApiResult.Success)
     }
 
     @Test

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryTlsPinComponentTest.kt
@@ -30,7 +30,9 @@ import org.junit.runner.RunWith
  * It stays a documented gap (SPEC section 9).
  *
  * The fixture's certificate SAN deliberately does not match the host it serves on, so these
- * tests also prove the pinned client ignores the certificate hostname (SPEC sections 6 and 14).
+ * tests also prove the PIN path ignores the certificate hostname (SPEC section 6). The
+ * platform-trusted path stays host-bound through the pin-aware verifier; being unreachable
+ * here (same reason as above), that binding is covered by PinnedHostnameVerifierTest on the JVM.
  */
 @RunWith(AndroidJUnit4::class)
 class FactoryTlsPinComponentTest {
@@ -53,10 +55,11 @@ class FactoryTlsPinComponentTest {
     @Test
     fun aPinnedConnectionIgnoresTheCertificateHostname() = runBlocking {
         // HttpsMockServer serves a certificate whose SAN never matches the loopback host it runs
-        // on, yet the connection succeeds: exact-cert pinning supersedes hostname verification,
-        // which the factory disables (SPEC sections 6 and 14). Guards against re-enabling the
-        // default hostname verifier on the pinned client - which would break connecting to a
-        // server by a LAN IP (and the E2E emulator's 10.0.2.2).
+        // on, yet the connection succeeds: the confirmed pin carries the connection, so the
+        // pin-aware hostname verifier ignores the hostname (SPEC section 6). Guards against
+        // losing that - a hostname-bound pin path would break connecting to a server by a LAN IP
+        // (and the E2E emulator's 10.0.2.2). Also proves, through the real Conscrypt stack, that
+        // the verifier can read the peer certificates it needs for the pin comparison.
         https.enqueueJson("[]")
 
         val result = client(https.fingerprint).listSpeakers()

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
@@ -67,6 +67,12 @@ object RatatoskrClientFactory {
 
         val baseBuilder = OkHttpClient.Builder()
             .sslSocketFactory(sslSocketFactory, trustManager)
+            // Exact-certificate trust-on-first-use pinning ([PinnedTrustManager]) already
+            // guarantees the server presents the one certificate the user confirmed by
+            // fingerprint, so hostname verification is redundant here - and enforcing it would
+            // break connecting to a server at an address not in its cert (a LAN IP, etc.). Let
+            // the pin alone decide (SPEC sections 6 and 14); mirrors CertificateInspector.
+            .hostnameVerifier { _, _ -> true }
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .addInterceptor(logging)

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
@@ -13,6 +13,7 @@ import io.github.xexanos.ratatoskr.network.generated.infrastructure.Serializer
 import io.github.xexanos.ratatoskr.network.generated.model.PlaybackState
 import io.github.xexanos.ratatoskr.network.generated.model.RefreshRequest
 import io.github.xexanos.ratatoskr.network.persist.TokenAccess
+import io.github.xexanos.ratatoskr.network.tls.PinnedHostnameVerifier
 import io.github.xexanos.ratatoskr.network.tls.PinnedTrustManager
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.EnumJsonAdapter
@@ -67,12 +68,13 @@ object RatatoskrClientFactory {
 
         val baseBuilder = OkHttpClient.Builder()
             .sslSocketFactory(sslSocketFactory, trustManager)
-            // Exact-certificate trust-on-first-use pinning ([PinnedTrustManager]) already
-            // guarantees the server presents the one certificate the user confirmed by
-            // fingerprint, so hostname verification is redundant here - and enforcing it would
-            // break connecting to a server at an address not in its cert (a LAN IP, etc.). Let
-            // the pin alone decide (SPEC sections 6 and 14); mirrors CertificateInspector.
-            .hostnameVerifier { _, _ -> true }
+            // Pin-aware hostname verification (SPEC section 6): when the user-confirmed
+            // fingerprint matches the served leaf, the hostname is ignored - the confirmed
+            // certificate is trustworthy at any address (a LAN IP, the E2E emulator's
+            // 10.0.2.2). On the platform-trusted path (reverse proxy, public CA) the standard
+            // verifier still applies; there it is the only host binding, because
+            // PinnedTrustManager consults the pin only after platform validation fails.
+            .hostnameVerifier(PinnedHostnameVerifier(fingerprint))
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .addInterceptor(logging)

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/tls/PinnedHostnameVerifier.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/tls/PinnedHostnameVerifier.kt
@@ -1,0 +1,46 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.tls
+
+import okhttp3.OkHttpClient
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLPeerUnverifiedException
+import javax.net.ssl.SSLSession
+
+/**
+ * Pin-aware hostname verification, the counterpart of [PinnedTrustManager] (SPEC section 6).
+ *
+ * When the served leaf certificate matches the user-confirmed fingerprint, the hostname is
+ * ignored: the user confirmed *that exact certificate*, so it is trustworthy at any address -
+ * which is what lets the app reach a self-signed server by a LAN IP (or the E2E emulator's
+ * 10.0.2.2) that appears in no certificate SAN.
+ *
+ * Everything else stays host-bound through [defaultVerifier]. That matters because
+ * [PinnedTrustManager] tries platform validation FIRST and consults the pin only on its
+ * failure: on the platform-trusted path (reverse proxy with a public CA) the hostname
+ * verifier is the only thing binding the certificate to the host. Dropping it there would
+ * let an on-path attacker connect with a validly issued certificate for their own domain.
+ * The same holds for a client built without a confirmed fingerprint.
+ */
+class PinnedHostnameVerifier(
+    private val expectedFingerprint: String?,
+    // OkHttp's standard verifier (OkHostnameVerifier), obtained through public API - the
+    // singleton itself lives in an internal package we must not reference.
+    private val defaultVerifier: HostnameVerifier = OkHttpClient().hostnameVerifier,
+) : HostnameVerifier {
+
+    override fun verify(hostname: String, session: SSLSession): Boolean {
+        val leaf = try {
+            session.peerCertificates.firstOrNull() as? X509Certificate
+        } catch (_: SSLPeerUnverifiedException) {
+            null
+        }
+        val pinCarries = leaf != null && expectedFingerprint != null &&
+            Fingerprints.matches(Fingerprints.sha256(leaf), expectedFingerprint)
+        return pinCarries || defaultVerifier.verify(hostname, session)
+    }
+}

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/tls/PinnedHostnameVerifierTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/tls/PinnedHostnameVerifierTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.tls
+
+import okhttp3.tls.HeldCertificate
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.Principal
+import java.security.cert.Certificate
+import javax.net.ssl.SSLPeerUnverifiedException
+import javax.net.ssl.SSLSession
+import javax.net.ssl.SSLSessionContext
+
+class PinnedHostnameVerifierTest {
+
+    // The platform-trusted path - a validly chained certificate for the WRONG host must stay
+    // rejected - cannot be reached by the instrumented TLS suite (the test CA is not in the
+    // system trust store, see FactoryTlsPinComponentTest). At this level the trust decision is
+    // out of the picture entirely: the verifier only sees the session, so the same cases cover
+    // both paths. What matters is that ONLY a leaf matching the confirmed pin lifts the host
+    // binding; anything else falls through to OkHttp's standard verifier.
+
+    private val served = HeldCertificate.Builder().addSubjectAlternativeName("example.com").build()
+    private val other = HeldCertificate.Builder().addSubjectAlternativeName("example.com").build()
+
+    private fun sessionServing(certificate: HeldCertificate): SSLSession =
+        FakeSslSession { arrayOf(certificate.certificate) }
+
+    @Test
+    fun `a leaf matching the confirmed pin is accepted at any hostname`() {
+        val verifier = PinnedHostnameVerifier(Fingerprints.sha256(served.certificate))
+
+        // The LAN-IP case: the confirmed certificate carries the connection, its SAN does not.
+        assertTrue(verifier.verify("192.168.1.20", sessionServing(served)))
+    }
+
+    @Test
+    fun `a non-matching leaf on a non-matching hostname is rejected`() {
+        val verifier = PinnedHostnameVerifier(Fingerprints.sha256(other.certificate))
+
+        // The attack case: a certificate that is not the confirmed one (on device it would be
+        // platform-trusted for the attacker's own domain) must stay bound to its hostname.
+        assertFalse(verifier.verify("192.168.1.20", sessionServing(served)))
+    }
+
+    @Test
+    fun `without a confirmed pin the client stays host-bound`() {
+        val verifier = PinnedHostnameVerifier(expectedFingerprint = null)
+
+        assertFalse(verifier.verify("192.168.1.20", sessionServing(served)))
+    }
+
+    @Test
+    fun `without a confirmed pin a hostname matching the SAN is accepted`() {
+        val verifier = PinnedHostnameVerifier(expectedFingerprint = null)
+
+        // Delegation to OkHttp's standard verifier works: the ordinary platform-trusted
+        // deployment keeps connecting exactly as before.
+        assertTrue(verifier.verify("example.com", sessionServing(served)))
+    }
+
+    @Test
+    fun `an unverified peer fails closed on a non-matching hostname`() {
+        val verifier = PinnedHostnameVerifier(Fingerprints.sha256(served.certificate))
+        val unverified = FakeSslSession { throw SSLPeerUnverifiedException("peer not verified") }
+
+        assertFalse(verifier.verify("192.168.1.20", unverified))
+    }
+
+    /**
+     * The verifier reads nothing but the peer certificates, both directly and through OkHttp's
+     * standard verifier, so that is the only [SSLSession] member a fake needs to implement.
+     * Every other accessor fails loudly rather than returning a misleading stub value.
+     */
+    private class FakeSslSession(
+        private val peerCertificates: () -> Array<Certificate>,
+    ) : SSLSession {
+        override fun getPeerCertificates(): Array<Certificate> = peerCertificates()
+
+        override fun getId(): ByteArray = unused()
+        override fun getSessionContext(): SSLSessionContext = unused()
+        override fun getCreationTime(): Long = unused()
+        override fun getLastAccessedTime(): Long = unused()
+        override fun invalidate(): Unit = unused()
+        override fun isValid(): Boolean = unused()
+        override fun putValue(name: String?, value: Any?): Unit = unused()
+        override fun getValue(name: String?): Any = unused()
+        override fun removeValue(name: String?): Unit = unused()
+        override fun getValueNames(): Array<String> = unused()
+        override fun getLocalCertificates(): Array<Certificate> = unused()
+
+        @Deprecated("Deprecated in Java")
+        @Suppress("OVERRIDE_DEPRECATION")
+        override fun getPeerCertificateChain(): Array<javax.security.cert.X509Certificate> = unused()
+
+        override fun getPeerPrincipal(): Principal = unused()
+        override fun getLocalPrincipal(): Principal = unused()
+        override fun getCipherSuite(): String = unused()
+        override fun getProtocol(): String = unused()
+        override fun getPeerHost(): String = unused()
+        override fun getPeerPort(): Int = unused()
+        override fun getPacketBufferSize(): Int = unused()
+        override fun getApplicationBufferSize(): Int = unused()
+
+        private fun unused(): Nothing =
+            throw UnsupportedOperationException("not expected to be read by the verifier")
+    }
+}

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/testutil/HttpsMockServer.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/testutil/HttpsMockServer.kt
@@ -27,9 +27,11 @@ import org.junit.rules.ExternalResource
  * to connect; [wrongFingerprint] to simulate a changed certificate.
  *
  * The served certificate's SAN deliberately does NOT match the host MockWebServer serves on:
- * the factory disables hostname verification on the pinned client (exact-cert pinning
- * supersedes it - SPEC sections 6 and 14), so the pin alone carries the connection. A green
- * handshake here therefore also proves the client ignores the certificate hostname.
+ * when the confirmed pin carries the connection, the client's pin-aware hostname verifier
+ * (`PinnedHostnameVerifier`) ignores the hostname. A green handshake here therefore proves
+ * hostname-independence of the PIN path only - the path this fixture reaches. The
+ * platform-trusted path stays host-bound and is out of this fixture's reach entirely (no
+ * system-trusted certificate); its host binding is covered by the verifier's JVM unit test.
  *
  * Use as a JUnit rule: it owns the whole per-test lifecycle - the server starts before each
  * test, and afterwards every client registered via [track] is closed and the server shut
@@ -96,10 +98,10 @@ class HttpsMockServer : ExternalResource() {
     fun takeRequest(): RecordedRequest = server.takeRequest()
 
     private companion object {
-        // A SAN that never matches the loopback host MockWebServer serves on. The pinned client
-        // disables hostname verification (exact-cert pinning decides), so the served cert needs
-        // no matching SAN - and using a foreign one makes the whole HTTPS suite prove that
-        // independence: re-enabling the default hostname verifier would fail every test here.
+        // A SAN that never matches the loopback host MockWebServer serves on. On the pin path
+        // the client's pin-aware hostname verifier ignores the hostname, so the served cert
+        // needs no matching SAN - and using a foreign one makes the whole HTTPS suite prove
+        // that pin-path independence: a hostname-bound pin path would fail every test here.
         private const val FOREIGN_SAN = "ratatoskr-e2e.invalid"
 
         // Minted once per class load, not per fixture instance: JUnit4 constructs a fresh test

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/testutil/HttpsMockServer.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/testutil/HttpsMockServer.kt
@@ -14,7 +14,6 @@ import okhttp3.mockwebserver.RecordedRequest
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
 import org.junit.rules.ExternalResource
-import java.net.InetAddress
 
 /**
  * A [MockWebServer] served over HTTPS with a self-signed certificate, for the instrumented
@@ -27,8 +26,10 @@ import java.net.InetAddress
  * self-signed / local-CA deployment (SPEC section 6). Pass [fingerprint] as the factory's pin
  * to connect; [wrongFingerprint] to simulate a changed certificate.
  *
- * The certificate's SAN is the loopback host name MockWebServer reports, so the production
- * hostname verifier (which the factory does not disable) is satisfied.
+ * The served certificate's SAN deliberately does NOT match the host MockWebServer serves on:
+ * the factory disables hostname verification on the pinned client (exact-cert pinning
+ * supersedes it - SPEC sections 6 and 14), so the pin alone carries the connection. A green
+ * handshake here therefore also proves the client ignores the certificate hostname.
  *
  * Use as a JUnit rule: it owns the whole per-test lifecycle - the server starts before each
  * test, and afterwards every client registered via [track] is closed and the server shut
@@ -95,14 +96,16 @@ class HttpsMockServer : ExternalResource() {
     fun takeRequest(): RecordedRequest = server.takeRequest()
 
     private companion object {
-        // canonicalHostName is what MockWebServer.url() reports for the loopback address; using
-        // it as the certificate SAN keeps the served cert valid for the URL the tests call.
-        private val loopbackHost: String = InetAddress.getByName("localhost").canonicalHostName
+        // A SAN that never matches the loopback host MockWebServer serves on. The pinned client
+        // disables hostname verification (exact-cert pinning decides), so the served cert needs
+        // no matching SAN - and using a foreign one makes the whole HTTPS suite prove that
+        // independence: re-enabling the default hostname verifier would fail every test here.
+        private const val FOREIGN_SAN = "ratatoskr-e2e.invalid"
 
         // Minted once per class load, not per fixture instance: JUnit4 constructs a fresh test
         // instance (and with it this fixture) for every @Test method, and the certificate
         // depends on no instance state - regenerating it per test is pure repeat keygen work.
         private val served: HeldCertificate =
-            HeldCertificate.Builder().addSubjectAlternativeName(loopbackHost).build()
+            HeldCertificate.Builder().addSubjectAlternativeName(FOREIGN_SAN).build()
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -149,6 +149,12 @@ certificate cannot be pinned at build time.
   fingerprint against the stored pin. Matching neither is a hard failure with a loud
   "certificate changed" warning and an explicit re-trust flow (settings → forget
   certificate).
+- Hostname verification is pin-aware: when the served leaf matches the confirmed
+  fingerprint, the hostname is not checked - the user confirmed that exact certificate, so
+  it is trustworthy at any address (typically a LAN IP that appears in no certificate SAN).
+  In every other case - the platform-trusted path, or no confirmed fingerprint - the
+  standard hostname verification applies unchanged; on the platform path it is the only
+  host binding, since the pin is consulted only after platform validation fails.
 - Scope of the change guarantee (deliberate trade-off): the "warn loudly if it changes"
   guarantee applies to the self-signed / local-CA deployment, which is the primary one and
   where the platform chain fails so the stored pin is always the deciding factor. When the


### PR DESCRIPTION
## Problem

The pinned **production** OkHttp client (`RatatoskrClientFactory`) kept OkHttp's **default hostname verifier** on every path. After a server is trusted by fingerprint, each request still verified the certificate hostname against its SAN - so the app could only reach the server at an address listed in the cert. That **breaks the normal case of connecting by LAN IP** (`https://192.168.x.x:8080`) and the E2E case (emulator -> `10.0.2.2`).

Surfaced while reviewing the server's zero-config self-signed TLS (ratatoskr-server#42): that cert's SAN is `localhost/127.0.0.1/ratatoskr`, so a phone connecting by LAN IP would fail hostname verification after trusting it.

## Fix

**Pin-aware hostname verification** (`PinnedHostnameVerifier`): the hostname check is skipped only when the served leaf certificate matches the user-confirmed fingerprint - the user confirmed *that exact certificate*, so it is trustworthy at any address. Everything else stays host-bound through OkHttp's standard verifier.

That distinction matters because `PinnedTrustManager` is **not** exact-cert pinning: it tries platform trust first and consults the pin only on its failure (SPEC section 6, reverse-proxy trade-off). An earlier revision of this PR disabled hostname verification wholesale, which on the platform-trusted path would have accepted a validly issued certificate for *any* domain - caught in review; see the resolved threads.

- `RatatoskrClientFactory`: `.hostnameVerifier(PinnedHostnameVerifier(fingerprint))` on `baseBuilder` (both the main and refresh clients inherit it).
- `PinnedHostnameVerifierTest` (JVM): covers the platform path the instrumented suite cannot reach - a non-matching leaf on a non-matching hostname is rejected (the attack case), no-pin clients stay host-bound, delegation to the default verifier works, unverified peers fail closed.
- `HttpsMockServer`: the served cert's SAN deliberately does not match the host it serves on, so the instrumented HTTPS suite proves hostname-independence **of the pin path** through the real Conscrypt stack; `FactoryTlsPinComponentTest` names the behaviour explicitly.
- SPEC section 6 records the pin-aware hostname rule.

## Verification

- `:core-network:testDebugUnitTest` - green, including the 5 new verifier tests.
- `:core-network:connectedDebugAndroidTest` on an emulator (API 36) - all 27 tests green, including the foreign-SAN pin suite (which also proves the verifier can read the peer certificates from Conscrypt's `SSLSession`).

Prerequisite for the cross-component E2E suite. ratatoskr-server#42 needs no change once this lands (its self-signed cert then works for any client address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)