### PR TITLE
feat(connect): tag the server-URL field for black-box E2E driving

### DIFF
--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
@@ -13,8 +13,6 @@ package io.github.xexanos.ratatoskr.ui
  * existing text/contentDescription instead - see the integration suite.
  */
 object UiTestTags {
-    /** Connect screen's server-URL field: prefilled ("https://") with only a floating label,
-     *  so it has no reliable text handle for black-box driving (the central E2E harness). */
     const val CONNECT_SERVER_URL = "connect_server_url"
     const val LIBRARY_SEARCH = "library_search"
     const val LIBRARY_ROW = "library_row"

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
@@ -13,6 +13,9 @@ package io.github.xexanos.ratatoskr.ui
  * existing text/contentDescription instead - see the integration suite.
  */
 object UiTestTags {
+    /** Connect screen's server-URL field: prefilled ("https://") with only a floating label,
+     *  so it has no reliable text handle for black-box driving (the central E2E harness). */
+    const val CONNECT_SERVER_URL = "connect_server_url"
     const val LIBRARY_SEARCH = "library_search"
     const val LIBRARY_ROW = "library_row"
     const val SPEAKER_ROW = "speaker_row"

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/connect/ConnectScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/connect/ConnectScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -54,6 +55,7 @@ import io.github.xexanos.ratatoskr.data.ConnectionManager
 import io.github.xexanos.ratatoskr.network.domain.CertificateInfo
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
 import io.github.xexanos.ratatoskr.network.tls.CertificateInspector
+import io.github.xexanos.ratatoskr.ui.UiTestTags
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -187,7 +189,7 @@ private fun ConnectContent(
             },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Go),
             shape = MaterialTheme.shapes.large,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(UiTestTags.CONNECT_SERVER_URL),
         )
         Spacer(Modifier.height(16.dp))
 


### PR DESCRIPTION
The first E2E run surfaced that the connect screen's **server-URL field** can't be driven
reliably black-box: it's prefilled (`https://`) with only a floating label, so Maestro tapping
the "Server URL" label lands the cursor mid-prefill → erase+type produced `https://localhost:8080s://`
→ "Invalid URL port" (screenshot in the e2e run).

Give the field a stable `testTag` (`connect_server_url`) so a black-box driver targets the field
node directly. This is exactly the case `UiTestTags` already documents — tag the elements that have
no reliable text/semantics handle (the URL field joins the search box, list rows, and the slider).

- `UiTestTags.CONNECT_SERVER_URL = "connect_server_url"`
- applied to the `OutlinedTextField` in `ConnectScreen.kt`

No behavior change; `testTagsAsResourceId` (app#15) already exposes it to UiAutomator/Maestro.
Once merged + a new `testing-<sha>` APK is published, the E2E flow switches to `id: connect_server_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)