### PR TITLE
ci: arm the E2E trigger, add the app release-promote gate, enforce version bumps

### DIFF
--- a/.github/workflows/pr-release-guards.yml
+++ b/.github/workflows/pr-release-guards.yml
@@ -1,0 +1,124 @@
+# Per-PR release guards. Two independent checks that keep the continuous-versioning release model
+# (SPEC section 8) honest, so a release-worthy change can never merge without the version bump the
+# automated tag gate (promote.yml) needs - "forgetting to bump" is caught here, loudly, instead of
+# silently producing no release later (promote.yml no-ops when the versionName is already tagged).
+#
+#   - commitlint    : every PR commit must be a Conventional Commit (mirrors the server repo). The
+#                     TYPES are load-bearing - the version-bump guard classifies them to decide
+#                     whether a bump is required. Rules live in commitlint.config.mjs at the root.
+#   - version-bump  : if the PR carries release-worthy commits (feat/fix/perf/breaking) it MUST
+#                     bump versionName/versionCode in app/build.gradle.kts by at least the semver
+#                     level those commits imply, keep versionCode consistent with the SPEC formula,
+#                     and ship the matching fastlane changelog. Otherwise no bump is required.
+#
+# Deliberately its own workflow (no paths-ignore): both jobs must ALWAYS report so they are safe to
+# make required status checks. A docs-only PR still runs them - commitlint always applies, and the
+# version-bump guard simply finds no release-worthy commits and passes.
+#
+# Concurrent-PR caveat: the guard compares against the PR's base. Two PRs branched off the same
+# commit can both bump to the same version and both pass; whichever merges second then re-points no
+# new tag. Enable branch protection's "require branches to be up to date before merging" so the
+# second PR must rebase onto the new main and its guard re-computes the next free version.
+
+name: PR release guards
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-release-guards-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The PR's commits must be present locally to lint the base..head range.
+          fetch-depth: 0
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+      - name: Lint the PR's commit messages
+        # npx with pinned versions (not a devDependency): this is a Kotlin/Gradle repo with no
+        # package.json, so the workspace stays JS-free. Pins match the server repo's commitlint job.
+        run: |
+          npx --yes -p @commitlint/cli@21.2.1 -p @commitlint/config-conventional@21.2.0 \
+            commitlint --from ${{ github.event.pull_request.base.sha }} \
+                       --to ${{ github.event.pull_request.head.sha }} --verbose
+
+  version-bump:
+    name: Version bump required for release-worthy changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need the base..head commit range and both revisions' app/build.gradle.kts.
+          fetch-depth: 0
+      - name: Require a version bump when the PR is release-worthy
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # --- classify the PR's commits (identical rules to the server's promote.yml) ----------
+          subjects="$(git log --format='%s' "${BASE_SHA}..${HEAD_SHA}")"
+          bodies="$(git log --format='%b' "${BASE_SHA}..${HEAD_SHA}")"
+          bump="none"
+          if grep -qE '^[a-z]+(\([^)]*\))?!:' <<< "$subjects" \
+             || grep -qE '^BREAKING[ -]CHANGE:' <<< "$bodies"; then
+            bump="major"
+          elif grep -qE '^feat(\([^)]*\))?:' <<< "$subjects"; then
+            bump="minor"
+          elif grep -qE '^(fix|perf)(\([^)]*\))?:' <<< "$subjects"; then
+            bump="patch"
+          fi
+
+          if [ "$bump" = "none" ]; then
+            echo "No release-worthy commits (feat/fix/perf/breaking) in this PR - a version bump is not required."
+            exit 0
+          fi
+
+          # --- read versionName/versionCode at base and head ------------------------------------
+          read_vn() { git show "$1:app/build.gradle.kts" | grep -E '^\s*versionName\s*=' | head -n1 | grep -oP 'versionName\s*=\s*"\K[^"]+'; }
+          read_vc() { git show "$1:app/build.gradle.kts" | grep -E '^\s*versionCode\s*='  | head -n1 | grep -oP 'versionCode\s*=\s*\K[0-9]+'; }
+          base_vn="$(read_vn "$BASE_SHA")"; base_vc="$(read_vc "$BASE_SHA")"
+          head_vn="$(read_vn "$HEAD_SHA")"; head_vc="$(read_vc "$HEAD_SHA")"
+
+          fail() { echo "::error::$*"; exit 1; }
+
+          case "$head_vn" in
+            [0-9]*.[0-9]*.[0-9]*) : ;;
+            *) fail "versionName '${head_vn}' is not MAJOR.MINOR.PATCH (SPEC section 8)." ;;
+          esac
+
+          # --- versionCode must equal the SPEC formula MAJOR*10000 + MINOR*100 + PATCH -----------
+          formula() { local M m p; IFS=. read -r M m p <<< "$1"; echo $(( M*10000 + m*100 + p )); }
+          want_vc="$(formula "$head_vn")"
+          [ "$head_vc" = "$want_vc" ] || fail "versionCode ${head_vc} does not match versionName ${head_vn} (expected ${want_vc} = MAJOR*10000+MINOR*100+PATCH, SPEC section 8)."
+
+          # --- the bump must be at least the level the commits imply ----------------------------
+          IFS=. read -r M m p <<< "$base_vn"
+          case "$bump" in
+            major) M=$((M+1)); m=0; p=0 ;;
+            minor) m=$((m+1)); p=0 ;;
+            patch) p=$((p+1)) ;;
+          esac
+          expected_vn="${M}.${m}.${p}"
+          # true when $1 >= $2 as versions
+          ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]; }
+          if ! ge "$head_vn" "$expected_vn"; then
+            fail "This PR has ${bump}-level commits but versionName is still ${head_vn} (base ${base_vn}). Bump to at least ${expected_vn} (versionCode $(formula "$expected_vn")) in app/build.gradle.kts, and add fastlane/metadata/android/en-US/changelogs/$(formula "$expected_vn").txt."
+          fi
+
+          # --- the fastlane changelog for the new versionCode must exist and be non-empty --------
+          changelog="fastlane/metadata/android/en-US/changelogs/${head_vc}.txt"
+          [ -s "$changelog" ] || fail "Missing (or empty) changelog ${changelog} for versionCode ${head_vc} (SPEC section 8 requires at least en-US)."
+
+          echo "OK: ${bump}-level PR bumps ${base_vn} (${base_vc}) -> ${head_vn} (${head_vc}); changelog present."

--- a/.github/workflows/pr-release-guards.yml
+++ b/.github/workflows/pr-release-guards.yml
@@ -68,6 +68,9 @@ jobs:
           set -euo pipefail
 
           # --- classify the PR's commits (identical rules to the server's promote.yml) ----------
+          # Only feat/fix/perf/breaking force a bump. `revert` is deliberately release-neutral here
+          # (matching the server's classifier), so reverting a shipped feat/fix does not by itself
+          # require a bump - rare, and kept consistent across the two pipelines on purpose.
           subjects="$(git log --format='%s' "${BASE_SHA}..${HEAD_SHA}")"
           bodies="$(git log --format='%b' "${BASE_SHA}..${HEAD_SHA}")"
           bump="none"
@@ -85,13 +88,18 @@ jobs:
             exit 0
           fi
 
+          fail() { echo "::error::$*"; exit 1; }
+
           # --- read versionName/versionCode at base and head ------------------------------------
-          read_vn() { git show "$1:app/build.gradle.kts" | grep -E '^\s*versionName\s*=' | head -n1 | grep -oP 'versionName\s*=\s*"\K[^"]+'; }
-          read_vc() { git show "$1:app/build.gradle.kts" | grep -E '^\s*versionCode\s*='  | head -n1 | grep -oP 'versionCode\s*=\s*\K[0-9]+'; }
+          # The trailing grep exits 1 when nothing matches; the `|| true` keeps that from aborting
+          # the whole script inside the command substitution (set -euo pipefail) BEFORE the
+          # empty-checks below can turn it into a clear message.
+          read_vn() { git show "$1:app/build.gradle.kts" 2>/dev/null | grep -E '^\s*versionName\s*=' | head -n1 | grep -oP 'versionName\s*=\s*"\K[^"]+' || true; }
+          read_vc() { git show "$1:app/build.gradle.kts" 2>/dev/null | grep -E '^\s*versionCode\s*='  | head -n1 | grep -oP 'versionCode\s*=\s*\K[0-9]+' || true; }
           base_vn="$(read_vn "$BASE_SHA")"; base_vc="$(read_vc "$BASE_SHA")"
           head_vn="$(read_vn "$HEAD_SHA")"; head_vc="$(read_vc "$HEAD_SHA")"
-
-          fail() { echo "::error::$*"; exit 1; }
+          [ -n "$head_vn" ] && [ -n "$head_vc" ] || fail "Could not read versionName/versionCode from app/build.gradle.kts at head (${HEAD_SHA})."
+          [ -n "$base_vn" ] && [ -n "$base_vc" ] || fail "Could not read versionName/versionCode from app/build.gradle.kts at base (${BASE_SHA})."
 
           case "$head_vn" in
             [0-9]*.[0-9]*.[0-9]*) : ;;

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -119,6 +119,14 @@ jobs:
             # should stop the latter at merge time, so reaching it here signals the guard was
             # bypassed or two PRs collided on the same version - warn loudly rather than no-op
             # silently (the whole point of the guard is that forgetting a bump is never quiet).
+            #
+            # This classification reads MAIN's commit subjects, so it assumes merges preserve the
+            # branch's Conventional Commits (merge-commit or rebase). Under SQUASH merges the main
+            # subject defaults to the (unlinted) PR title, so a release-worthy squash titled e.g.
+            # `ci: ...` would be misread as benign here and reported as ::notice:: instead of
+            # ::warning::. This only degrades THIS diagnostic - the actual bump enforcement runs on
+            # the PR's own base..head commits in pr-release-guards.yml, which are linted regardless
+            # of merge strategy. SPEC section 8 records the no-squash requirement for main.
             subjects="$(git log --format='%s' "v${version}..${commit}")"
             bodies="$(git log --format='%b' "v${version}..${commit}")"
             if grep -qE '^[a-z]+(\([^)]*\))?!:' <<< "$subjects" \

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -113,7 +113,21 @@ jobs:
 
           # Idempotent gate: cut the tag only if this version has not been released yet.
           if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
-            echo "::notice::v${version} already exists - nothing to release (build promoted for an already-released version)."
+            # Distinguish the benign case (a non-release commit - docs/chore/ci - promoted past an
+            # already-released version) from the one that means a bump was MISSED: release-worthy
+            # commits between v${version} and this commit. The PR guard (pr-release-guards.yml)
+            # should stop the latter at merge time, so reaching it here signals the guard was
+            # bypassed or two PRs collided on the same version - warn loudly rather than no-op
+            # silently (the whole point of the guard is that forgetting a bump is never quiet).
+            subjects="$(git log --format='%s' "v${version}..${commit}")"
+            bodies="$(git log --format='%b' "v${version}..${commit}")"
+            if grep -qE '^[a-z]+(\([^)]*\))?!:' <<< "$subjects" \
+               || grep -qE '^BREAKING[ -]CHANGE:' <<< "$bodies" \
+               || grep -qE '^(feat|fix|perf)(\([^)]*\))?:' <<< "$subjects"; then
+              echo "::warning::v${version} is already tagged, yet release-worthy commits landed since it (commit ${commit}). A version bump was likely missed (guard bypassed, or two PRs collided on ${version}) - NO release was cut. Bump the version on main to ship these changes."
+            else
+              echo "::notice::v${version} already exists - nothing to release (non-release commit promoted past an already-released version)."
+            fi
             echo "release=false" >> "$GITHUB_OUTPUT"
           else
             echo "Cutting v${version} at ${commit} (from ${TAG})."

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,159 @@
+# Promote a *tested* build to a release — the second half of the flow that starts in
+# release-validation.yml. It does NOT rebuild: it cuts an annotated v<versionName> git tag at
+# the validated commit and creates a GitHub release carrying the exact unsigned release APK that
+# E2E validated (copied from that commit's testing-<sha> pre-release), so what ships is provably
+# what passed. This mirrors the server's promote.yml (which re-tags the tested image by digest);
+# an APK cannot be "re-tagged" the way a container image can (versionName/versionCode are compiled
+# into the APK bytes and covered by the signature), so the tag is what carries the version, and
+# F-Droid rebuilds from that tag and signs with its own key (SPEC section 8). The attached APK is
+# a convenience for sideloaders, not what F-Droid consumes.
+#
+# The version is NOT computed here (unlike the server, which derives semver from conventional
+# commits): versionName lives in app/build.gradle.kts and a human bumps it (SPEC section 8). This
+# gate automates the "wait for green, then tag" half — it cuts the tag for the version declared at
+# the validated commit, but ONLY if that version has not already been released. So landing more
+# commits at an unchanged versionName cuts nothing new; the tag is cut once, at the first
+# E2E-green commit that carries a not-yet-released version (normally the version-bump commit).
+#
+# Triggers:
+#   - repository_dispatch (app-e2e-passed): ratatoskr-e2e fires this on a green app-validated run,
+#     carrying the release_tag (the testing-<sha> pre-release it tested) and the commit. This is
+#     the automatic path: release-validation.yml -> E2E -> (on pass) promote.yml.
+#   - workflow_dispatch: manual promotion of a known-good testing-<sha> pre-release.
+
+name: Promote (release)
+
+on:
+  repository_dispatch:
+    types: [app-e2e-passed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Tested pre-release tag to promote (e.g. testing-abc1234)
+        required: true
+
+permissions:
+  # Push the v<versionName> git tag, create the GitHub release, and read/download the
+  # testing-<sha> pre-release's assets — all in this repo, so the per-run GITHUB_TOKEN suffices.
+  contents: write
+
+concurrency:
+  # Serialize promotions: two concurrent runs could both read "v0.1.0 does not exist yet" and race
+  # to push the same tag. Queue instead, and never cancel one in flight (a half-cut release is
+  # worse than a delayed one).
+  group: app-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve the source pre-release tag and commit
+        id: plan
+        env:
+          EVENT: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ github.event.client_payload.release_tag }}
+          DISPATCH_COMMIT: ${{ github.event.client_payload.commit }}
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "repository_dispatch" ]; then
+            tag="$DISPATCH_TAG"
+            commit="$DISPATCH_COMMIT"
+          else
+            tag="$INPUT_TAG"
+            commit=""   # resolved from the release below when dispatched manually
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::No release_tag to promote."; exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "commit=${commit}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out (full history + tags)
+        uses: actions/checkout@v7
+        with:
+          # Need the tag list (to test whether v<versionName> already exists) and the ability to
+          # push a new tag at an arbitrary commit; the contract submodule is not needed here (we
+          # neither build nor generate the client).
+          fetch-depth: 0
+
+      - name: Resolve the commit, read versionName, decide whether to release
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.plan.outputs.tag }}
+          COMMIT: ${{ steps.plan.outputs.commit }}
+        run: |
+          set -euo pipefail
+
+          # A manual dispatch carries no commit; take the one the pre-release was cut at.
+          commit="$COMMIT"
+          if [ -z "$commit" ]; then
+            commit="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json targetCommitish --jq .targetCommitish)"
+          fi
+          if ! git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+            echo "::error::Promote commit ${commit} is not in this repository."; exit 1
+          fi
+          # Releases come from main history only, mirroring the server's promote.yml. A manually
+          # dispatched feature-branch build is not tag-worthy.
+          if ! git merge-base --is-ancestor "$commit" origin/main; then
+            echo "::error::Commit ${commit} is not on main; refusing to cut a release tag."; exit 1
+          fi
+
+          # versionName is the single source of truth for the version (SPEC section 8). Read it at
+          # the validated commit, not at HEAD, so a later bump on main cannot mislabel this release.
+          line="$(git show "${commit}:app/build.gradle.kts" | grep -E '^\s*versionName\s*=' | head -n1)"
+          version="$(printf '%s' "$line" | grep -oP 'versionName\s*=\s*"\K[^"]+')"
+          if [ -z "$version" ]; then
+            echo "::error::Could not read versionName from app/build.gradle.kts at ${commit}."; exit 1
+          fi
+
+          # Idempotent gate: cut the tag only if this version has not been released yet.
+          if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
+            echo "::notice::v${version} already exists - nothing to release (build promoted for an already-released version)."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Cutting v${version} at ${commit} (from ${TAG})."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "commit=${commit}" >> "$GITHUB_OUTPUT"
+
+      # Fetch the E2E-validated bytes BEFORE tagging, so a missing/pruned asset fails the run
+      # before any tag is pushed (never a tag with no release behind it - the server orders its
+      # publish-before-tag for the same reason).
+      - name: Download the validated unsigned release APK
+        if: steps.version.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.plan.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p publish
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'ratatoskr-release-unsigned.apk' --dir publish
+          test -s publish/ratatoskr-release-unsigned.apk
+
+      - name: Push the version tag and create the GitHub release
+        if: steps.version.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          COMMIT: ${{ steps.version.outputs.commit }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Annotated tag matching the fdroiddata UpdateCheckMode: Tags pattern (v<versionName>).
+          # Tags pushed with GITHUB_TOKEN do not trigger other workflows - no dispatch loop.
+          git tag -a "v${VERSION}" -m "Release v${VERSION}" "${COMMIT}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "${COMMIT}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --verify-tag \
+            publish/ratatoskr-release-unsigned.apk

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -97,8 +97,9 @@ jobs:
             echo "::error::Promote commit ${commit} is not in this repository."; exit 1
           fi
           # Releases come from main history only, mirroring the server's promote.yml. A manually
-          # dispatched feature-branch build is not tag-worthy.
-          if ! git merge-base --is-ancestor "$commit" origin/main; then
+          # dispatched feature-branch build is not tag-worthy. HEAD is main here: checkout defaults
+          # to the repository's default branch for both repository_dispatch and workflow_dispatch.
+          if ! git merge-base --is-ancestor "$commit" HEAD; then
             echo "::error::Commit ${commit} is not on main; refusing to cut a release tag."; exit 1
           fi
 

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -10,8 +10,10 @@
 #      and the unsigned release APK (what F-Droid signs). Each validated commit gets its own
 #      pre-release so a given build stays retrievable by its commit; the `testing-` prefix and
 #      prerelease flag make clear these are throwaway, not stable releases.
-#   3. Then trigger the cross-component E2E suite - placeholder until the ratatoskr-e2e
-#      repository's workflow exists.
+#   3. Then dispatch the cross-component E2E suite (Xexanos/ratatoskr-e2e) with this build's
+#      pre-release tag. On a green E2E run it dispatches `app-e2e-passed` back, which drives
+#      promote.yml - the git-tag release gate (a v<versionName> tag is cut only for a version
+#      not yet released). Mirrors the server's container.yml -> E2E -> promote.yml flow.
 #
 # A separate scheduled job prunes `testing-*` pre-releases (and their tags) older than the
 # retention window below, so the per-commit releases do not accumulate forever.
@@ -171,21 +173,32 @@ jobs:
             publish/ratatoskr-minified.apk
             publish/ratatoskr-release-unsigned.apk
 
-      # Placeholder until the ratatoskr-e2e repository's workflow exists: it will be driven
-      # by a repository_dispatch carrying this run's per-commit pre-release tag, e.g.
-      #
-      #   - name: Trigger the cross-component E2E suite
-      #     if: github.ref == 'refs/heads/main'
-      #     run: |
-      #       gh api repos/Xexanos/ratatoskr-e2e/dispatches \
-      #         -f event_type=app-validated \
-      #         -F 'client_payload[release_tag]=${{ steps.tag.outputs.name }}' \
-      #         -F 'client_payload[commit]=${{ github.sha }}'
-      #     env:
-      #       GH_TOKEN: ${{ secrets.E2E_DISPATCH_TOKEN }}  # PAT with access to ratatoskr-e2e
-      - name: Trigger the E2E suite (placeholder)
+      # Hand this validated build to the cross-component E2E suite (Xexanos/ratatoskr-e2e).
+      # The dispatch carries the per-commit pre-release tag (the APK it just published, which the
+      # E2E harness pulls) and the commit. E2E runs server@release-:latest x app@THIS build; on a
+      # green run it dispatches `app-e2e-passed` back here, which drives promote.yml (the git-tag
+      # release gate). Mirrors the server's container.yml -> E2E -> promote.yml flow, one direction
+      # per component. Cross-repo dispatch needs a PAT with access to ratatoskr-e2e (the per-run
+      # GITHUB_TOKEN is scoped to THIS repo only), stored as E2E_DISPATCH_TOKEN. If that secret is
+      # missing the step FAILS: the testing APKs are published but their E2E gate silently not
+      # running would be worse than a red pipeline (same stance as the server's trigger-e2e).
+      - name: Trigger the cross-component E2E suite
         if: github.ref == 'refs/heads/main'
-        run: echo "ratatoskr-e2e does not exist yet - see the commented dispatch step above."
+        env:
+          E2E_DISPATCH_TOKEN: ${{ secrets.E2E_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$E2E_DISPATCH_TOKEN" ]; then
+            echo "::error title=E2E dispatch failed::E2E_DISPATCH_TOKEN is not set - cannot trigger the E2E suite for ${RELEASE_TAG}. Add the secret (a PAT with access to ratatoskr-e2e)." >&2
+            exit 1
+          fi
+          echo "Dispatching app-validated E2E for ${RELEASE_TAG} (${SHA})"
+          GH_TOKEN="$E2E_DISPATCH_TOKEN" gh api \
+            repos/${{ github.repository_owner }}/ratatoskr-e2e/dispatches \
+            -f event_type=app-validated \
+            -F "client_payload[release_tag]=${RELEASE_TAG}" \
+            -F "client_payload[commit]=${SHA}"
 
   # Prune the per-commit testing-* pre-releases so they do not accumulate forever. Runs only
   # on the daily schedule (or a manual dispatch); deletes any testing-* pre-release older than

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -188,6 +188,7 @@ jobs:
           E2E_DISPATCH_TOKEN: ${{ secrets.E2E_DISPATCH_TOKEN }}
           RELEASE_TAG: ${{ steps.tag.outputs.name }}
           SHA: ${{ github.sha }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           if [ -z "$E2E_DISPATCH_TOKEN" ]; then
             echo "::error title=E2E dispatch failed::E2E_DISPATCH_TOKEN is not set - cannot trigger the E2E suite for ${RELEASE_TAG}. Add the secret (a PAT with access to ratatoskr-e2e)." >&2
@@ -195,7 +196,7 @@ jobs:
           fi
           echo "Dispatching app-validated E2E for ${RELEASE_TAG} (${SHA})"
           GH_TOKEN="$E2E_DISPATCH_TOKEN" gh api \
-            repos/${{ github.repository_owner }}/ratatoskr-e2e/dispatches \
+            "repos/${OWNER}/ratatoskr-e2e/dispatches" \
             -f event_type=app-validated \
             -F "client_payload[release_tag]=${RELEASE_TAG}" \
             -F "client_payload[commit]=${SHA}"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 100
-        versionName = "0.1.0"
+        versionCode = 10000
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,41 @@
+// Commit types are load-bearing here: the version-bump guard (pr-release-guards.yml) classifies
+// a PR's commits to decide whether a versionName/versionCode bump is REQUIRED - feat!/BREAKING
+// CHANGE -> major, feat -> minor, fix/perf -> patch, anything else -> no bump required. CI
+// enforces this shape on every PR commit (the "commitlint" job in the same workflow). Mirrors the
+// server repo's convention so the two pipelines read commits the same way (SPEC section 8).
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // The standard types plus this repo's established ones - all of the extras are
+    // release-neutral (the guard only requires a bump for feat/fix/perf/breaking).
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+        // repo-specific:
+        'deps', // dependency bumps (dependabot's configured prefix); use fix(deps): when a runtime bump should ship a release
+        'review', // addressing PR review feedback
+        'spec', // docs/SPEC.md changes
+        'comment', // comment-only corrections
+      ],
+    ],
+    // Style rules relaxed for dependabot, which capitalizes subjects ("deps: Bump ...")
+    // and writes long changelog URLs into bodies. The gate exists so the TYPE parses -
+    // subject cosmetics are not what the release pipeline reads.
+    'subject-case': [0],
+    'body-max-line-length': [0],
+    // Dependabot subjects (scoped package + path) routinely exceed the 100-char default.
+    'header-max-length': [0],
+  },
+}

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -30,12 +30,14 @@ export default {
         'comment', // comment-only corrections
       ],
     ],
-    // Style rules relaxed for dependabot, which capitalizes subjects ("deps: Bump ...")
-    // and writes long changelog URLs into bodies. The gate exists so the TYPE parses -
-    // subject cosmetics are not what the release pipeline reads.
+    // These three style checks are disabled for ALL commits, not just Dependabot's - only the
+    // commit TYPE is load-bearing (the guard and the release pipeline read nothing else), so
+    // subject/header/body cosmetics are deliberately unenforced. Dependabot is what forces the
+    // issue (it capitalizes subjects like "deps: Bump ..." and writes long changelog URLs and
+    // scoped-package headers well past 100 chars), but the relaxation is global: a 120-char
+    // header on a hand-written commit passes too. Kept off on purpose; revisit if noisy.
     'subject-case': [0],
     'body-max-line-length': [0],
-    // Dependabot subjects (scoped package + path) routinely exceed the 100-char default.
     'header-max-length': [0],
   },
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -207,7 +207,14 @@ keeps token ciphertext out of cloud backups entirely.
   (`0.1.0` → `100`, `1.2.3` → `10203`): monotonic, gapless in meaning, and reconstructible
   from the version name alone, so the two can never disagree. Both live only in
   `app/build.gradle.kts`. Changelog files are named after the version code
-  (`fastlane/.../changelogs/<versionCode>.txt`), as fastlane requires.
+  (`fastlane/.../changelogs/<versionCode>.txt`), as fastlane requires. CI enforces the bump
+  so it is never forgotten: `pr-release-guards.yml` fails any PR whose commits are
+  release-worthy (feat/fix/perf/breaking, per Conventional Commits — themselves linted by a
+  commitlint job mirrored from the server) unless it raises `versionName`/`versionCode` by at
+  least the implied semver level, keeps `versionCode` consistent with the formula above, and
+  adds the matching `en-US` changelog. Non-release commits (docs/chore/ci/deps/…) require no
+  bump. This is the continuous-versioning half of the flow: because every release-worthy merge
+  bumps, every such green `main` commit is a fresh version the tag gate below can cut.
 - **Releases are git tags, cut automatically once E2E is green.** A release is an
   annotated tag `v<versionName>` (e.g. `v0.1.0`) on a `main` commit whose full validation
   has passed. The fdroiddata recipe uses `UpdateCheckMode: Tags` against that pattern. The

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -208,15 +208,36 @@ keeps token ciphertext out of cloud backups entirely.
   from the version name alone, so the two can never disagree. Both live only in
   `app/build.gradle.kts`. Changelog files are named after the version code
   (`fastlane/.../changelogs/<versionCode>.txt`), as fastlane requires.
-- **Releases are git tags.** A release is an annotated tag `v<versionName>` (e.g.
-  `v0.1.0`) on a `main` commit whose post-merge validation (section 9) has passed. The
-  fdroiddata recipe uses `UpdateCheckMode: Tags` against that pattern. The release
-  process, in order: bump `versionCode`/`versionName` in `app/build.gradle.kts`, add the
-  `changelogs/<versionCode>.txt` files (at least `en-US`), merge to `main`, wait for the
-  release-validation workflow to go green, then tag that commit and push the tag. GitHub
-  releases are optional extras; the tag is what F-Droid consumes.
+- **Releases are git tags, cut automatically once E2E is green.** A release is an
+  annotated tag `v<versionName>` (e.g. `v0.1.0`) on a `main` commit whose full validation
+  has passed. The fdroiddata recipe uses `UpdateCheckMode: Tags` against that pattern. The
+  version itself is never computed by CI — `versionName` in `app/build.gradle.kts` is the
+  single source of truth and a human bumps it; CI only automates the *wait-for-green,
+  then-tag* half. The release process, in order: bump `versionCode`/`versionName`, add the
+  `changelogs/<versionCode>.txt` files (at least `en-US`), and merge to `main`. From there
+  CI takes over: `release-validation.yml` validates the shrunk build post-merge, publishes
+  it to a per-commit `testing-<sha>` pre-release, and dispatches the cross-component E2E
+  suite (`Xexanos/ratatoskr-e2e`, run as server@release-`:latest` × app@this-build); on a
+  green run E2E dispatches `app-e2e-passed` back, and `promote.yml` cuts the `v<versionName>`
+  tag at the validated commit and creates a GitHub release carrying the E2E-validated
+  unsigned APK (copied from the pre-release, not rebuilt). The tag is cut only when that
+  `versionName` is not already tagged: the gate is idempotent, so landing further commits at
+  an unchanged version cuts nothing new, and the tag lands on the first E2E-green commit that
+  carries a not-yet-released version (normally the bump commit). A red E2E run cuts no
+  release — the tag can only ever point at a commit that passed. GitHub releases are optional
+  extras; the tag is what F-Droid consumes. Manual promotion of a known-good `testing-<sha>`
+  pre-release stays available via `promote.yml`'s `workflow_dispatch`. This mirrors the
+  server's `container.yml` → E2E → `promote.yml` flow, one direction per component.
+- **Why the version must be set before the build.** Unlike an OCI image — whose version is
+  a registry tag pointing at already-built, digest-addressed bytes, applied (and changed)
+  after the fact without a rebuild — an APK's `versionName`/`versionCode` are compiled into
+  `AndroidManifest.xml` and covered by the APK signature, so they are part of the artifact
+  bytes. There is therefore no "build once, choose the version later by re-tagging" for the
+  app: the version lives in source, and F-Droid rebuilds from the tag regardless. The git
+  tag, not a re-tag of a built artifact, is what carries the version.
 - **Signing: F-Droid signs its own builds.** The repository produces an unsigned release
-  APK (the release-validation workflow publishes it per validated commit) and F-Droid's
+  APK (the release-validation workflow publishes it per validated commit, and `promote.yml`
+  attaches that same validated APK to the `v<versionName>` GitHub release) and F-Droid's
   build server builds from the tag and signs the result with the F-Droid key. There is
   deliberately no developer release keystore: nothing secret to manage, rotate, or leak,
   and no `Binaries:`/`AllowedAPKSigningKeys` reproducibility contract to keep. Trade-off,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -215,6 +215,13 @@ keeps token ciphertext out of cloud backups entirely.
   adds the matching `en-US` changelog. Non-release commits (docs/chore/ci/deps/…) require no
   bump. This is the continuous-versioning half of the flow: because every release-worthy merge
   bumps, every such green `main` commit is a fresh version the tag gate below can cut.
+  - **Merges to `main` must preserve the branch's Conventional Commits** — use merge-commit or
+    rebase, **not squash** (disable squash merges in the repository settings). The per-PR guard
+    reads the branch's own `base..head` commits and so is robust to the strategy, but the
+    tag gate's post-hoc "missed a bump?" diagnostic (`promote.yml`) classifies `main`'s history,
+    where a squash would substitute the unlinted PR title for the real commit subjects and could
+    mislabel a missed release-worthy change as benign. Keeping commits intact on `main` also
+    mirrors how the server derives its version.
 - **Releases are git tags, cut automatically once E2E is green.** A release is an
   annotated tag `v<versionName>` (e.g. `v0.1.0`) on a `main` commit whose full validation
   has passed. The fdroiddata recipe uses `UpdateCheckMode: Tags` against that pattern. The

--- a/fastlane/metadata/android/de-DE/changelogs/100.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/100.txt
@@ -1,1 +1,0 @@
-Erste Entwicklungsversion.

--- a/fastlane/metadata/android/de-DE/changelogs/10000.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10000.txt
@@ -1,0 +1,1 @@
+Erste Veröffentlichung.

--- a/fastlane/metadata/android/en-US/changelogs/100.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100.txt
@@ -1,1 +1,0 @@
-Initial development release.

--- a/fastlane/metadata/android/en-US/changelogs/10000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10000.txt
@@ -1,0 +1,1 @@
+Initial release.


### PR DESCRIPTION
Arms the app side of the cross-component pipeline and automates release tagging via the E2E gate. Structure deliberately modeled on the server repo (`container.yml` → E2E → `promote.yml`).

## What's included

**1. E2E trigger armed** (`release-validation.yml`)
The placeholder echo is gone: on a green on-device validation the workflow dispatches `app-validated` to `Xexanos/ratatoskr-e2e` (carrying the `testing-<sha>` tag + commit). Needs the `E2E_DISPATCH_TOKEN` secret; the step fails loudly if it is missing.

**2. App release gate** (new: `promote.yml`)
Triggered by the `app-e2e-passed` dispatch the E2E side fires back on a green run. Cuts an annotated `v<versionName>` tag at the validated commit plus a GitHub release carrying the E2E-validated unsigned APK (copied from the `testing-<sha>` pre-release, **no rebuild**) — but only if that `versionName` is not already tagged. `versionName` stays the human-maintained source of truth (SPEC §8); only the "wait for green, then tag" half is automated. F-Droid rebuilds from the tag and signs itself.

**3. Version-bump enforcement** (new: `pr-release-guards.yml` + `commitlint.config.mjs`)
- `commitlint` — Conventional Commits on every PR commit (mirrored from the server).
- `version-bump` — for release-worthy commits (feat/fix/perf/breaking) the PR **must** raise `versionName`/`versionCode` by at least the implied semver level, keep the `MAJOR*10000+MINOR*100+PATCH` formula, and ship the `en-US` changelog; otherwise it goes red. Catches a forgotten bump at merge time instead of letting `promote.yml` silently no-op later.
- `promote.yml` now warns loudly (instead of a silent notice) when it lands on an already-tagged `versionName` that has release-worthy commits since (the race / bypassed-guard case).

**4. SPEC §8** now describes the automated, E2E-gated tagging, the bump enforcement, and *why* the version must be set before the build on Android (compiled into the manifest + signed — no "retag" as with OCI images).

**5. Version baseline set to 1.0.0** (`chore(release)`)
`versionName` `0.1.0` → `1.0.0`, `versionCode` `100` → `10000`; the fastlane changelog is renamed `100.txt` → `10000.txt` (en-US + de-DE) and reworded to "initial release". Safe to re-baseline: `0.1.0` was never released (no `v*` tag exists, only throwaway `testing-*` pre-releases).

## Steps required outside this PR

- [ ] **E2E repo**: apply the counterpart patch (accepts `app-validated` + dispatches back). Patch is ready; see the session handoff.
- [ ] Secret `E2E_DISPATCH_TOKEN` (this repo) — PAT with access to `ratatoskr-e2e`.
- [ ] Secret `APP_PROMOTE_TOKEN` (E2E repo) — PAT allowed to dispatch this repo.
- [ ] Branch protection on `main`: make `Conventional Commits` + `Version bump required for release-worthy changes` **required checks**; enable "require branches to be up to date before merging". **Disable squash merges** (use merge-commit or rebase) so Conventional Commits reach `main` - see SPEC §8.

## Verification

YAML of all workflows validated; the guard bash (classification, formula, semver comparison) tested locally. The real dispatch loop is only testable live once the branch is pushed and the secrets exist.

## Note on the server template

The template was `promote.yml` from server **PR #55** (`promote-auto-semver`, still open), not server `main`. Comments stating "the server derives semver from Conventional Commits" assume #55 lands.