### PR TITLE
chore(release): initialize version at 1.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 100
-        versionName = "0.1.0"
+        versionCode = 10000
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/fastlane/metadata/android/de-DE/changelogs/100.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/100.txt
@@ -1,1 +1,0 @@
-Erste Entwicklungsversion.

--- a/fastlane/metadata/android/de-DE/changelogs/10000.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10000.txt
@@ -1,0 +1,1 @@
+Erste Veröffentlichung.

--- a/fastlane/metadata/android/en-US/changelogs/100.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100.txt
@@ -1,1 +1,0 @@
-Initial development release.

--- a/fastlane/metadata/android/en-US/changelogs/10000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10000.txt
@@ -1,0 +1,1 @@
+Initial release.


### PR DESCRIPTION
Sets the app's baseline version to **1.0.0** (`versionCode` 10000), replacing the `0.1.0`/100 placeholder.

## Changes
- `app/build.gradle.kts`: `versionName` `0.1.0` → `1.0.0`, `versionCode` `100` → `10000` (`MAJOR*10000 + MINOR*100 + PATCH`, SPEC §8).
- Rename the fastlane changelog `100.txt` → `10000.txt` (en-US + de-DE) so it matches the new `versionCode`, and reword "initial development release" → "initial release", which fits a 1.0.0.

## Notes
- Safe to re-baseline: `0.1.0` was never released — no `v*` tag exists (only throwaway `testing-*` pre-releases), so nothing shipped under `versionCode` 100.
- The SPEC §8 lines mentioning `0.1.0`/`v0.1.0` are formula/tag *examples* and are intentionally left unchanged.
- Independent of the release-plumbing PR #37; can merge in any order.