### PR TITLE
ci: rename app-validated dispatch to app-candidate

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -16,7 +16,7 @@
 # E2E-green commit that carries a not-yet-released version (normally the version-bump commit).
 #
 # Triggers:
-#   - repository_dispatch (app-e2e-passed): ratatoskr-e2e fires this on a green app-validated run,
+#   - repository_dispatch (app-e2e-passed): ratatoskr-e2e fires this on a green app-candidate run,
 #     carrying the release_tag (the testing-<sha> pre-release it tested) and the commit. This is
 #     the automatic path: release-validation.yml -> E2E -> (on pass) promote.yml.
 #   - workflow_dispatch: manual promotion of a known-good testing-<sha> pre-release.

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -194,10 +194,10 @@ jobs:
             echo "::error title=E2E dispatch failed::E2E_DISPATCH_TOKEN is not set - cannot trigger the E2E suite for ${RELEASE_TAG}. Add the secret (a PAT with access to ratatoskr-e2e)." >&2
             exit 1
           fi
-          echo "Dispatching app-validated E2E for ${RELEASE_TAG} (${SHA})"
+          echo "Dispatching app-candidate E2E for ${RELEASE_TAG} (${SHA})"
           GH_TOKEN="$E2E_DISPATCH_TOKEN" gh api \
             "repos/${OWNER}/ratatoskr-e2e/dispatches" \
-            -f event_type=app-validated \
+            -f event_type=app-candidate \
             -F "client_payload[release_tag]=${RELEASE_TAG}" \
             -F "client_payload[commit]=${SHA}"
 


### PR DESCRIPTION
Re-lands the dispatch rename that **missed the #37 merge window**: the rename commit landed on
#37's branch *after* it was merged, so `main` still dispatches `event_type=app-validated`.

Renames the E2E-trigger dispatch **`app-validated` → `app-candidate`** (callback `app-e2e-passed`
unchanged), matching the unified `<component>-<phase>` scheme across the repos:
**ratatoskr-e2e#3** (listens for `app-candidate` / `server-candidate`) and **ratatoskr-server#63**
(`server-candidate` / `server-e2e-passed`).

⚠️ `repository_dispatch` `event_type` is unvalidated, so this must merge together with
ratatoskr-e2e#3, or the app→E2E trigger silently no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)