### PR TITLE
ci: publish a developer-signed sideload APK on release

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -215,7 +215,7 @@ jobs:
             --notes "## Install
 
           - **F-Droid** (primary): builds and signs this release itself from the \`v${VERSION}\` tag.
-          - **Sideload**: download \`ratatoskr-v${VERSION}.apk\` (developer-signed; certificate SHA-256 \`D9:91:F4:BC:63:BB:23:F5:87:F0:58:57:10:65:AC:B2:00:3E:61:BC:A7:DD:12:95:BB:C2:21:7D:62:87:AD:DF\`).
+          - **Sideload**: download \`ratatoskr-v${VERSION}.apk\` (developer-signed; certificate SHA-256 \`1B:4D:89:B7:B6:CF:20:70:22:A2:38:25:E5:65:1B:F5:6B:4F:CF:CA:EC:BB:35:10:97:72:30:42:66:F0:11:B1\`).
 
           The two channels are signed with different keys: a device cannot switch between an F-Droid install and a sideloaded install without uninstalling first. \`ratatoskr-release-unsigned.apk\` is the unsigned build the E2E suite validated (provenance artifact, not installable)." \
             --generate-notes \

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,8 +5,14 @@
 # what passed. This mirrors the server's promote.yml (which re-tags the tested image by digest);
 # an APK cannot be "re-tagged" the way a container image can (versionName/versionCode are compiled
 # into the APK bytes and covered by the signature), so the tag is what carries the version, and
-# F-Droid rebuilds from that tag and signs with its own key (SPEC section 8). The attached APK is
-# a convenience for sideloaders, not what F-Droid consumes.
+# F-Droid rebuilds from that tag and signs with its own key (SPEC section 8).
+#
+# The release carries two APKs (SPEC section 8): the unsigned validated bytes (provenance — not
+# installable, and not what F-Droid consumes either), and a developer-signed copy of those same
+# bytes (ratatoskr-v<versionName>.apk) as the explicit sideload alternative to F-Droid. Signing
+# adds a signature to the validated APK; it never rebuilds. The two channels use different keys,
+# so a device cannot switch between an F-Droid install and a sideload install without
+# uninstalling first — the release notes say so.
 #
 # The version is NOT computed here (unlike the server, which derives semver from conventional
 # commits): versionName lives in app/build.gradle.kts and a human bumps it (SPEC section 8). This
@@ -159,6 +165,34 @@ jobs:
             --pattern 'ratatoskr-release-unsigned.apk' --dir publish
           test -s publish/ratatoskr-release-unsigned.apk
 
+      # Sign the validated bytes for the sideload channel (SPEC section 8): the exact APK the
+      # E2E suite validated, plus a developer signature — never a rebuild. Runs BEFORE tagging
+      # for the same reason the download does: a missing secret or a bad keystore fails the run
+      # before any tag is pushed.
+      - name: Sign the sideload APK
+        if: steps.version.outputs.release == 'true'
+        env:
+          KEYSTORE_B64: ${{ secrets.RELEASE_KEYSTORE }}
+          KEYSTORE_PASS: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "$KEYSTORE_B64" ] || [ -z "$KEYSTORE_PASS" ]; then
+            echo "::error::RELEASE_KEYSTORE / RELEASE_KEYSTORE_PASSWORD secrets are not set — cannot sign the sideload APK."; exit 1
+          fi
+          keystore="$RUNNER_TEMP/release.p12"
+          printf '%s' "$KEYSTORE_B64" | base64 -d > "$keystore"
+          bt="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n1)"
+          # zipalign before signing (v2+ signatures cover the whole file). AGP's unsigned APK
+          # is already aligned; -f makes this idempotent rather than a failure.
+          "$bt/zipalign" -f 4 publish/ratatoskr-release-unsigned.apk "$RUNNER_TEMP/aligned.apk"
+          # --ks-pass env: keeps the password out of argv and logs (never log secrets).
+          "$bt/apksigner" sign \
+            --ks "$keystore" --ks-key-alias ratatoskr-release --ks-pass env:KEYSTORE_PASS \
+            --out "publish/ratatoskr-v${VERSION}.apk" "$RUNNER_TEMP/aligned.apk"
+          "$bt/apksigner" verify --print-certs "publish/ratatoskr-v${VERSION}.apk"
+          rm -f "$keystore"
+
       - name: Push the version tag and create the GitHub release
         if: steps.version.outputs.release == 'true'
         env:
@@ -173,10 +207,18 @@ jobs:
           # Tags pushed with GITHUB_TOKEN do not trigger other workflows - no dispatch loop.
           git tag -a "v${VERSION}" -m "Release v${VERSION}" "${COMMIT}"
           git push origin "v${VERSION}"
+          # The generated notes (commit log) are appended after this install guidance by gh.
           gh release create "v${VERSION}" \
             --repo "$GITHUB_REPOSITORY" \
             --target "${COMMIT}" \
             --title "v${VERSION}" \
+            --notes "## Install
+
+          - **F-Droid** (primary): builds and signs this release itself from the \`v${VERSION}\` tag.
+          - **Sideload**: download \`ratatoskr-v${VERSION}.apk\` (developer-signed; certificate SHA-256 \`D9:91:F4:BC:63:BB:23:F5:87:F0:58:57:10:65:AC:B2:00:3E:61:BC:A7:DD:12:95:BB:C2:21:7D:62:87:AD:DF\`).
+
+          The two channels are signed with different keys: a device cannot switch between an F-Droid install and a sideloaded install without uninstalling first. \`ratatoskr-release-unsigned.apk\` is the unsigned build the E2E suite validated (provenance artifact, not installable)." \
             --generate-notes \
             --verify-tag \
+            "publish/ratatoskr-v${VERSION}.apk" \
             publish/ratatoskr-release-unsigned.apk

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -190,7 +190,9 @@ jobs:
           "$bt/apksigner" sign \
             --ks "$keystore" --ks-key-alias ratatoskr-release --ks-pass env:KEYSTORE_PASS \
             --out "publish/ratatoskr-v${VERSION}.apk" "$RUNNER_TEMP/aligned.apk"
-          "$bt/apksigner" verify --print-certs "publish/ratatoskr-v${VERSION}.apk"
+          "$bt/apksigner" verify --print-certs "publish/ratatoskr-v${VERSION}.apk" \
+            | grep -Fq 'certificate SHA-256 digest: 1b4d89b7b6cf207022a23825e5651bf56b4fcfcaecbb35109772304266f011b1' \
+            || { echo "::error::Signing certificate does not match the pinned fingerprint - wrong or rotated RELEASE_KEYSTORE secret."; exit 1; }
           rm -f "$keystore"
 
       - name: Push the version tag and create the GitHub release

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -240,7 +240,8 @@ keeps token ciphertext out of cloud backups entirely.
   suite (`Xexanos/ratatoskr-e2e`, run as server@release-`:latest` × app@this-build); on a
   green run E2E dispatches `app-e2e-passed` back, and `promote.yml` cuts the `v<versionName>`
   tag at the validated commit and creates a GitHub release carrying the E2E-validated
-  unsigned APK (copied from the pre-release, not rebuilt). The tag is cut only when that
+  APK bytes (copied from the pre-release, not rebuilt): the unsigned APK plus a
+  developer-signed copy for sideloading (see the signing bullet below). The tag is cut only when that
   `versionName` is not already tagged: the gate is idempotent, so landing further commits at
   an unchanged version cuts nothing new, and the tag lands on the first E2E-green commit that
   carries a not-yet-released version (normally the bump commit). A red E2E run cuts no
@@ -255,16 +256,27 @@ keeps token ciphertext out of cloud backups entirely.
   bytes. There is therefore no "build once, choose the version later by re-tagging" for the
   app: the version lives in source, and F-Droid rebuilds from the tag regardless. The git
   tag, not a re-tag of a built artifact, is what carries the version.
-- **Signing: F-Droid signs its own builds.** The repository produces an unsigned release
-  APK (the release-validation workflow publishes it per validated commit, and `promote.yml`
-  attaches that same validated APK to the `v<versionName>` GitHub release) and F-Droid's
-  build server builds from the tag and signs the result with the F-Droid key. There is
-  deliberately no developer release keystore: nothing secret to manage, rotate, or leak,
-  and no `Binaries:`/`AllowedAPKSigningKeys` reproducibility contract to keep. Trade-off,
-  recorded: Android signature continuity makes this permanent for this `applicationId` —
-  switching later to developer-signed reproducible builds would force every user to
-  uninstall and reinstall. The "aim for a reproducible build" bullet above stays as build
-  hygiene (deterministic inputs, minimal toolchain), not as a signing strategy.
+- **Signing: two install channels, two keys.** F-Droid remains the primary channel: its
+  build server builds from the `v<versionName>` tag and signs the result with the F-Droid
+  key — it consumes nothing but the tag. In addition, the GitHub release explicitly offers
+  sideloading as an alternative: `promote.yml` signs the E2E-validated unsigned APK (the
+  exact bytes that passed, never a rebuild) with a developer release key and attaches it
+  as `ratatoskr-v<versionName>.apk`, alongside the `ratatoskr-release-unsigned.apk` it is
+  derived from (kept as the provenance artifact — an unsigned APK is not installable). The
+  key is a PKCS12 keystore held in GitHub Actions secrets (`RELEASE_KEYSTORE`,
+  base64-encoded, and `RELEASE_KEYSTORE_PASSWORD`; alias `ratatoskr-release`), with an
+  offline backup outside CI. The signing certificate's SHA-256 fingerprint, for
+  `apksigner verify --print-certs` checks, is
+  `D9:91:F4:BC:63:BB:23:F5:87:F0:58:57:10:65:AC:B2:00:3E:61:BC:A7:DD:12:95:BB:C2:21:7D:62:87:AD:DF`.
+  Trade-offs, recorded: (a) Android signature continuity makes the two channels mutually
+  exclusive per install — a device cannot move between an F-Droid install and a sideload
+  install without uninstall + reinstall (and the data loss that implies); release notes
+  must say so. (b) There is now a secret to manage: the keystore must stay backed up, and
+  losing it orphans every sideload install (F-Droid installs are unaffected). There is
+  still no `Binaries:`/`AllowedAPKSigningKeys` reproducibility contract to keep — the
+  sideload APK is a parallel channel, not an F-Droid input. The "aim for a reproducible
+  build" bullet above stays as build hygiene (deterministic inputs, minimal toolchain),
+  not as a signing strategy.
 - Choose a reasonable `minSdk` that covers the encrypted-storage and TLS requirements; the
   agent proposes the exact value.
 - Release shrinking (R8) is **enabled**, and the conditions that once blocked it are resolved:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -267,7 +267,7 @@ keeps token ciphertext out of cloud backups entirely.
   base64-encoded, and `RELEASE_KEYSTORE_PASSWORD`; alias `ratatoskr-release`), with an
   offline backup outside CI. The signing certificate's SHA-256 fingerprint, for
   `apksigner verify --print-certs` checks, is
-  `D9:91:F4:BC:63:BB:23:F5:87:F0:58:57:10:65:AC:B2:00:3E:61:BC:A7:DD:12:95:BB:C2:21:7D:62:87:AD:DF`.
+  `1B:4D:89:B7:B6:CF:20:70:22:A2:38:25:E5:65:1B:F5:6B:4F:CF:CA:EC:BB:35:10:97:72:30:42:66:F0:11:B1`.
   Trade-offs, recorded: (a) Android signature continuity makes the two channels mutually
   exclusive per install — a device cannot move between an F-Droid install and a sideload
   install without uninstall + reinstall (and the data loss that implies); release notes


### PR DESCRIPTION
## Why

Downloading the release APK from GitHub fails to install ("the package appears to be invalid"): the attached APK is unsigned, and Android refuses unsigned APKs. The old promote.yml comment calling it "a convenience for sideloaders" was factually wrong. Sideloading is now offered as an explicit alternative to F-Droid.

## What

- **promote.yml**: new "Sign the sideload APK" step — zipaligns and signs the E2E-validated unsigned APK (the exact bytes that passed, never a rebuild) with a developer release key from the new `RELEASE_KEYSTORE` (base64 PKCS12) / `RELEASE_KEYSTORE_PASSWORD` secrets, verifies the result, and attaches `ratatoskr-v<versionName>.apk` alongside the unsigned provenance APK. Runs before the tag push, so a missing secret fails the run before any tag exists. Release notes now carry install guidance including the channel-exclusivity warning.
- **SPEC section 8**: the "F-Droid signs its own builds" decision becomes "two install channels, two keys", recording the trade-offs: signature continuity makes F-Droid and sideload mutually exclusive per install, and there is now a keystore to manage and back up. F-Droid's path is unchanged (it consumes only the tag).

## Notes

- The two repo secrets must be set before the next promotion runs, otherwise the sign step fails (intentionally, before tagging).
- The existing v1.0.0 release has already been fixed out-of-band: its validated APK was signed with the same key and uploaded as `ratatoskr-v1.0.0.apk`, and the release notes got the same install section.
- Certificate SHA-256: `1B:4D:89:B7:B6:CF:20:70:22:A2:38:25:E5:65:1B:F5:6B:4F:CF:CA:EC:BB:35:10:97:72:30:42:66:F0:11:B1`
- Not testable in CI until the next version bump promotes (the idempotent gate no-ops on already-released versions); the signing commands themselves were exercised locally against the v1.0.0 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

