### PR TITLE
docs(spec): add LAN auto-discovery to planned post-v1 features

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -525,3 +525,10 @@ the radar:
 
 - **Cover art.** The library projection carries no cover URL today. Once the server serves cover
   images (server SPEC section 16), show artwork in the library and now-playing views.
+
+- **Server auto-discovery on the LAN (mDNS/Zeroconf).** Mirrors the server-side feature (server
+  SPEC section 16): instead of the user typing the server's URL by hand on first connect
+  (sections 5 and 6), the app would browse for Ratatoskr instances advertised via mDNS/Bonjour and
+  offer them as selectable candidates. The existing trust-on-first-use certificate-fingerprint
+  confirmation stays mandatory regardless of how the address was obtained, so discovery only
+  removes the typing, not the trust step.


### PR DESCRIPTION
## Summary
- Adds a new item to SPEC section 14 (Planned features, post-v1), mirroring the server SPEC: instead of typing the server URL by hand on first connect, the app would browse for Ratatoskr instances advertised via mDNS/Bonjour and offer them as selectable candidates.
- Notes that the existing trust-on-first-use certificate-fingerprint confirmation stays mandatory regardless of how the address was obtained.
- Companion doc-only PR on the server side: https://github.com/Xexanos/ratatoskr-server/pull/77 (docs/plan-server-autodiscovery).

This is a planning-doc entry only — no implementation, no contract change.

## Test plan
- [x] Doc-only change; no build/test impact.