### PR TITLE
feat: add a German translation and per-app language config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 10001
-        versionName = "1.0.1"
+        versionCode = 10100
+        versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ratatoskr">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,7 +18,7 @@
 
     <!-- Sign in -->
     <string name="signin_title">Bei Audiobookshelf anmelden</string>
-    <string name="signin_subtitle">Verwende deinen vorhandenen Benutzernamen und dein Passwort.</string>
+    <string name="signin_subtitle">Verwende deinen bestehenden Benutzernamen und dein Passwort.</string>
     <string name="signin_username_label">Benutzername</string>
     <string name="signin_password_label">Passwort</string>
     <string name="signin_action">Anmelden</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,71 @@
+<resources>
+    <!-- Connect -->
+    <string name="connect_welcome_title">Willkommen bei Ratatoskr</string>
+    <string name="connect_welcome_subtitle">Verbinde dich mit deinem Ratatoskr-Server, um Hörbücher auf deinen Sonos-Lautsprechern abzuspielen.</string>
+    <string name="connect_server_url_label">Server-URL</string>
+    <string name="connect_url_locked_desc">URL gesperrt, während das Zertifikat bestätigt wird</string>
+    <string name="connect_action_connect">Verbinden</string>
+    <string name="connect_inspecting">Serverzertifikat wird gelesen...</string>
+    <string name="connect_action_retry">Erneut versuchen</string>
+    <string name="connect_confirm_title">Erste Verbindung: Zertifikat bestätigen</string>
+    <string name="connect_cert_subject_label">Inhaber</string>
+    <string name="connect_cert_issuer_label">Aussteller</string>
+    <string name="connect_cert_valid_until_label">Gültig bis</string>
+    <string name="connect_cert_fingerprint_label">SHA-256-Fingerabdruck</string>
+    <string name="connect_cert_compare_hint">Vergleiche diesen Fingerabdruck mit dem, den dein Server anzeigt, bevor du ihm vertraust.</string>
+    <string name="connect_action_trust">Vertrauen und fortfahren</string>
+    <string name="connect_action_cancel">Abbrechen</string>
+
+    <!-- Sign in -->
+    <string name="signin_title">Bei Audiobookshelf anmelden</string>
+    <string name="signin_subtitle">Verwende deinen vorhandenen Benutzernamen und dein Passwort.</string>
+    <string name="signin_username_label">Benutzername</string>
+    <string name="signin_password_label">Passwort</string>
+    <string name="signin_action">Anmelden</string>
+
+    <!-- Library -->
+    <string name="library_title">Bibliothek</string>
+    <string name="library_now_playing">Aktuelle Wiedergabe</string>
+    <string name="library_settings">Einstellungen</string>
+    <string name="library_search_placeholder">Hörbücher durchsuchen</string>
+    <string name="library_empty_title">Deine Bibliothek ist leer</string>
+    <string name="library_no_results_title">Keine Treffer</string>
+    <string name="library_empty_body">Hörbücher von deinem Audiobookshelf-Server erscheinen hier.</string>
+    <string name="library_no_results_body">Keine Hörbücher passen zu %1$s. Versuche es mit einer kürzeren Suche.</string>
+    <string name="library_finished">Abgeschlossen</string>
+    <string name="library_percent">%1$d&#160;%%</string>
+
+    <!-- Speakers -->
+    <string name="speakers_title">Lautsprecher auswählen</string>
+    <string name="speakers_subtitle">Die Wiedergabe startet auf dem ausgewählten Lautsprecher.</string>
+    <string name="speakers_starting">Wiedergabe wird gestartet...</string>
+    <string name="speakers_empty_title">Keine Lautsprecher gefunden</string>
+    <string name="speakers_empty_hint">Stelle sicher, dass deine Sonos-Lautsprecher eingeschaltet und vom Server aus erreichbar sind.</string>
+    <string name="speakers_group">Gruppe</string>
+    <string name="speakers_group_members">Gruppe: %1$s</string>
+    <string name="speakers_kind_speaker">Lautsprecher</string>
+
+    <!-- Now playing -->
+    <string name="nowplaying_header">AKTUELLE WIEDERGABE</string>
+    <string name="nowplaying_nothing_playing">Gerade wird nichts wiedergegeben.</string>
+    <string name="nowplaying_action_play">Wiedergeben</string>
+    <string name="nowplaying_action_pause">Pausieren</string>
+    <string name="nowplaying_action_stop">Stoppen</string>
+    <string name="nowplaying_state_playing">Wird wiedergegeben</string>
+    <string name="nowplaying_state_paused">Pausiert</string>
+    <string name="nowplaying_state_buffering">Wird gepuffert</string>
+    <string name="nowplaying_state_finished">Abgeschlossen</string>
+    <string name="nowplaying_state_stopped">Gestoppt</string>
+
+    <!-- Settings -->
+    <string name="settings_title">Einstellungen</string>
+    <string name="settings_section_server">Server</string>
+    <string name="settings_section_security">Sicherheit</string>
+    <string name="settings_section_account">Konto</string>
+    <string name="settings_not_configured">Nicht konfiguriert</string>
+    <string name="settings_connected">Über HTTPS verbunden</string>
+    <string name="settings_not_connected">Über den Startbildschirm verbinden</string>
+    <string name="settings_forget_cert">Zertifikat vergessen und neu vertrauen</string>
+    <string name="settings_forget_cert_hint">Entfernt das gepinnte Zertifikat. Bei der nächsten Verbindung bestätigst du den Fingerabdruck des Servers erneut.</string>
+    <string name="settings_sign_out">Abmelden</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Ratatoskr</string>
+    <string name="app_name" translatable="false">Ratatoskr</string>
 
     <!-- Connect -->
     <string name="connect_welcome_title">Welcome to Ratatoskr</string>
@@ -58,7 +58,7 @@
     <string name="nowplaying_state_buffering">Buffering</string>
     <string name="nowplaying_state_finished">Finished</string>
     <string name="nowplaying_state_stopped">Stopped</string>
-    <string name="nowplaying_state_unknown">-</string>
+    <string name="nowplaying_state_unknown" translatable="false">-</string>
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Declares the languages the app itself ships (Android 13+ reads this for the per-app
+     language setting). Keep in sync with the values-<locale> resource directories. -->
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="de" />
+</locale-config>

--- a/fastlane/metadata/android/de-DE/changelogs/10100.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10100.txt
@@ -1,0 +1,1 @@
+Deutsche Übersetzung ergänzt; App-Sprachen für die Pro-App-Spracheinstellung ab Android 13 registriert.

--- a/fastlane/metadata/android/en-US/changelogs/10100.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10100.txt
@@ -1,0 +1,1 @@
+Add a German translation and register the app languages for Android 13+ per-app language settings.


### PR DESCRIPTION
## Why

The app ships only default (English) strings, so a German-locale device stays English — the localization plumbing (all screens use `stringResource`) was fine, the translations simply did not exist.

## What

- **`values-de/strings.xml`**: German translation of all 58 translatable strings. Terminology follows the official Audiobookshelf app's German translation (informal du-form); `library_percent` uses a non-breaking space before `%` per German typography.
- **`values/strings.xml`**: `app_name` and the `-` unknown-state placeholder are marked `translatable="false"` (and therefore absent from `values-de`).
- **`locales_config.xml` + manifest `android:localeConfig`**: declares en + de so Android 13+ lists the app in the per-app language settings; ignored on older releases.
- **Version bump 1.0.1 → 1.1.0** (versionCode 10100) with fastlane changelogs (en-US, de-DE): user-visible feature, release-worthy per the PR guard.

## Notes

- Merging this releases v1.1.0 through the promote pipeline — the first release to exercise the new sideload-signing step from #45 end to end.
- Verified locally: `:app:assembleDebug` builds and the merged `values-de` resources contain the app's German strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)