### PR TITLE
ci: retry the flaky emulator-package download before android-emulator-runner

### DIFF
--- a/.github/actions/preinstall-emulator/action.yml
+++ b/.github/actions/preinstall-emulator/action.yml
@@ -20,13 +20,24 @@ runs:
   steps:
     - shell: bash
       run: |
-        # Not on PATH yet at this point in the job - the emulator-runner action's own
-        # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-        sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-        if [ -z "$sdkmanager" ]; then
-          echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+        # sdkmanager is NOT on PATH here - the emulator-runner action's own JS wrapper is
+        # what adds it later, so resolve it explicitly. It lives at
+        # cmdline-tools/latest/bin/sdkmanager - the exact path android-emulator-runner
+        # expects to be populated. Anchor to that; fall back to a versioned cmdline-tools
+        # dir (find -maxdepth 3 reaches <version>/bin/sdkmanager, which is three levels
+        # below cmdline-tools) only if `latest` is absent.
+        sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+        if [ ! -x "$sdkmanager" ]; then
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 3 -name sdkmanager -type f 2>/dev/null | head -n1)"
+        fi
+        if [ -z "$sdkmanager" ] || [ ! -x "$sdkmanager" ]; then
+          echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install (the emulator-runner action will still try its own install)."
           exit 0
         fi
+        # Log the resolved path so the run proves this step actually installs rather than
+        # silently no-opping (the bug this replaces: a too-shallow find matched nothing and
+        # the step exit-0'd every time, so the retry loop below never ran).
+        echo "Pre-installing the Android Emulator package via ${sdkmanager}"
         yes | "$sdkmanager" --licenses > /dev/null
         ok=false
         for attempt in 1 2 3; do

--- a/.github/actions/preinstall-emulator/action.yml
+++ b/.github/actions/preinstall-emulator/action.yml
@@ -1,0 +1,40 @@
+# Pre-installs the Android Emulator SDK package, retrying the flaky download, before a job
+# hands off to reactivecircus/android-emulator-runner.
+#
+# Why: sdkmanager's emulator-package download intermittently arrives as a corrupted zip
+# ("Error on ZipFile unknown archive"), which the runner action treats as fatal - PR #43
+# lost a full run to exactly this. Installing it ourselves first, with retries, means the
+# action's own install (the same `sdkmanager --install emulator` command) just finds the
+# package already there and no-ops. Used by every emulator job in instrumented-tests.yml
+# and by release-validation.yml (a flake there reads as a main regression, not a PR
+# failure).
+#
+# Local composite action (referenced as ./.github/actions/preinstall-emulator): lives in
+# the same commit as its callers, so - unlike the third-party actions this repo pins by SHA
+# - it is not (and cannot be) SHA-pinned. Requires the repo to be checked out first, which
+# every calling job already does.
+name: Pre-install the Android Emulator SDK package
+description: Retry sdkmanager's flaky emulator-package download before android-emulator-runner hits it.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # Not on PATH yet at this point in the job - the emulator-runner action's own
+        # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+        sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+        if [ -z "$sdkmanager" ]; then
+          echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+          exit 0
+        fi
+        yes | "$sdkmanager" --licenses > /dev/null
+        ok=false
+        for attempt in 1 2 3; do
+          if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
+            ok=true
+            break
+          fi
+          echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+          sleep 10
+        done
+        [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."

--- a/.github/actions/preinstall-emulator/action.yml
+++ b/.github/actions/preinstall-emulator/action.yml
@@ -38,7 +38,13 @@ runs:
         # silently no-opping (the bug this replaces: a too-shallow find matched nothing and
         # the step exit-0'd every time, so the retry loop below never ran).
         echo "Pre-installing the Android Emulator package via ${sdkmanager}"
+        # `yes` gets SIGPIPE (exit 141) the moment sdkmanager stops reading - benign and the
+        # normal way `yes | cmd` ends, but this step runs under `set -o pipefail`, which would
+        # otherwise fail on it. Drop pipefail just for this pipe so sdkmanager's own exit
+        # status is what counts (a real license failure still surfaces via set -e).
+        set +o pipefail
         yes | "$sdkmanager" --licenses > /dev/null
+        set -o pipefail
         ok=false
         for attempt in 1 2 3; do
           if "$sdkmanager" --install emulator --channel=0 > /dev/null; then

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -94,10 +94,17 @@ jobs:
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         if: steps.avd-cache.outputs.cache-hit != 'true'
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi
@@ -169,10 +176,17 @@ jobs:
       # before the action's own install hits it.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi
@@ -273,10 +287,17 @@ jobs:
       # before the action's own install hits it.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi
@@ -371,10 +392,17 @@ jobs:
       # before the action's own install hits it.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi
@@ -455,10 +483,17 @@ jobs:
       # before the action's own install hits it.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi
@@ -542,10 +577,17 @@ jobs:
       # before the action's own install hits it.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -86,6 +86,26 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
+      # sdkmanager's emulator-package download intermittently arrives as a corrupted zip
+      # ("Error on ZipFile unknown archive"), which the runner action treats as fatal -
+      # PR #43 lost ~10 min to a re-run over exactly this. Installing it ourselves first,
+      # with retries, means the action's own install (same command) just finds it already
+      # there and no-ops.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+
       # On a cache miss, create the AVD once and let it save a snapshot (no -no-snapshot-save).
       - name: Warm the AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -144,6 +164,22 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
+
+      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
+      # before the action's own install hits it.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
 
       - name: Run the core-network component suite
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
@@ -233,6 +269,22 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
+      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
+      # before the action's own install hits it.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+
       - name: Run the whole-app integration flow
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
@@ -315,6 +367,22 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
+      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
+      # before the action's own install hits it.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+
       - name: Run the wire smoke against the minified build
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
@@ -382,6 +450,22 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
+
+      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
+      # before the action's own install hits it.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
 
       - name: Run the accessibility suite in light mode
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
@@ -453,6 +537,22 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
+
+      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
+      # before the action's own install hits it.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
 
       - name: Run the accessibility suite in dark mode
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -86,32 +86,12 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
-      # sdkmanager's emulator-package download intermittently arrives as a corrupted zip
-      # ("Error on ZipFile unknown archive"), which the runner action treats as fatal -
-      # PR #43 lost ~10 min to a re-run over exactly this. Installing it ourselves first,
-      # with retries, means the action's own install (same command) just finds it already
-      # there and no-ops.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale. Only on a cache miss,
+      # where warm-avd actually boots the emulator below.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       # On a cache miss, create the AVD once and let it save a snapshot (no -no-snapshot-save).
       - name: Warm the AVD snapshot
@@ -172,28 +152,10 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
-      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
-      # before the action's own install hits it.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       - name: Run the core-network component suite
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
@@ -283,28 +245,10 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
-      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
-      # before the action's own install hits it.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       - name: Run the whole-app integration flow
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
@@ -388,28 +332,10 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
-      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
-      # before the action's own install hits it.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       - name: Run the wire smoke against the minified build
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
@@ -479,28 +405,10 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
-      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
-      # before the action's own install hits it.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       - name: Run the accessibility suite in light mode
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
@@ -573,28 +481,10 @@ jobs:
             ~/.android/adb*
           key: avd-api${{ matrix.api-level }}-x86_64-default-pixel_6
 
-      # See the warm-avd job above: retry sdkmanager's flaky emulator-package download
-      # before the action's own install hits it.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       - name: Run the accessibility suite in dark mode
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -102,32 +102,11 @@ jobs:
             ~/.android/adb*
           key: avd-api36-x86_64-default-pixel_6
 
-      # sdkmanager's emulator-package download intermittently arrives as a corrupted zip
-      # ("Error on ZipFile unknown archive"), which the runner action treats as fatal - see
-      # the same step in instrumented-tests.yml (PR #43). Installing it ourselves first,
-      # with retries, means the action's own install (same command) just finds it already
-      # there and no-ops. Worth the same fix here: a flake on this job reads as a main
-      # regression, not a PR failure.
+      # Retry sdkmanager's flaky emulator-package download before the action's own install
+      # hits it - see the composite action for the full rationale. Worth the same fix here:
+      # a flake on this job reads as a main regression, not a PR failure.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
-        run: |
-          # Not on PATH yet at this point in the job - the emulator-runner action's own
-          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
-          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
-          if [ -z "$sdkmanager" ]; then
-            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
-            exit 0
-          fi
-          yes | "$sdkmanager" --licenses > /dev/null
-          ok=false
-          for attempt in 1 2 3; do
-            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
-              ok=true
-              break
-            fi
-            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
-            sleep 10
-          done
-          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+        uses: ./.github/actions/preinstall-emulator
 
       - name: Run the integration flow against the minified build
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -110,10 +110,17 @@ jobs:
       # regression, not a PR failure.
       - name: Pre-install the Android Emulator SDK package (retry the flaky download)
         run: |
-          yes | sdkmanager --licenses > /dev/null
+          # Not on PATH yet at this point in the job - the emulator-runner action's own
+          # JS wrapper is what adds it. Resolve the binary directly under $ANDROID_HOME.
+          sdkmanager="$(find "$ANDROID_HOME/cmdline-tools" -maxdepth 2 -name sdkmanager -type f | head -n1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::warning::sdkmanager not found under \$ANDROID_HOME/cmdline-tools; skipping the pre-install."
+            exit 0
+          fi
+          yes | "$sdkmanager" --licenses > /dev/null
           ok=false
           for attempt in 1 2 3; do
-            if sdkmanager --install emulator --channel=0 > /dev/null; then
+            if "$sdkmanager" --install emulator --channel=0 > /dev/null; then
               ok=true
               break
             fi

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -102,6 +102,26 @@ jobs:
             ~/.android/adb*
           key: avd-api36-x86_64-default-pixel_6
 
+      # sdkmanager's emulator-package download intermittently arrives as a corrupted zip
+      # ("Error on ZipFile unknown archive"), which the runner action treats as fatal - see
+      # the same step in instrumented-tests.yml (PR #43). Installing it ourselves first,
+      # with retries, means the action's own install (same command) just finds it already
+      # there and no-ops. Worth the same fix here: a flake on this job reads as a main
+      # regression, not a PR failure.
+      - name: Pre-install the Android Emulator SDK package (retry the flaky download)
+        run: |
+          yes | sdkmanager --licenses > /dev/null
+          ok=false
+          for attempt in 1 2 3; do
+            if sdkmanager --install emulator --channel=0 > /dev/null; then
+              ok=true
+              break
+            fi
+            echo "::warning::sdkmanager emulator install failed (attempt ${attempt}/3), retrying in 10s..."
+            sleep 10
+          done
+          [ "$ok" = true ] || echo "::warning::All 3 attempts failed; the emulator-runner action gets one more try."
+
       - name: Run the integration flow against the minified build
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:


### PR DESCRIPTION
## Summary
- sdkmanager's Android Emulator package download intermittently arrives as a corrupted zip ("Error on ZipFile unknown archive"), which `reactivecircus/android-emulator-runner` treats as fatal — PR #43 lost a full run to exactly this.
- Adds a pre-install step (`sdkmanager --install emulator --channel=0`, retried up to 3x with a 10s backoff) before every call to the action, in both `instrumented-tests.yml` (6 jobs) and `release-validation.yml` (1 job). If our install succeeds, the action's own install of the same package is a no-op; if all 3 attempts fail, the action still gets one more try and fails visibly as before.
- Included `release-validation.yml` too, since a flake there reports as a main-branch failure rather than a PR failure.

## Test plan
- [ ] Open this PR and confirm the `Instrumented tests` checks pass (exercises the new pre-install step on every job that hits it).
- [ ] Spot-check one job's log for the new "Pre-install the Android Emulator SDK package" step to confirm it runs and, on success, that the action's own "Install Android SDK" step reports the package already present.