### PR TITLE
fix: load the whole library through cursor pagination (infinite scroll)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 10100
-        versionName = "1.1.0"
+        versionCode = 10101
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AccessibilityChecksTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AccessibilityChecksTest.kt
@@ -30,6 +30,8 @@ import io.github.xexanos.ratatoskr.ui.connect.ConnectErrorPreview
 import io.github.xexanos.ratatoskr.ui.connect.ConnectIdlePreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryEmptyPreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryLoadedPreview
+import io.github.xexanos.ratatoskr.ui.library.LibraryLoadMoreFailedPreview
+import io.github.xexanos.ratatoskr.ui.library.LibraryLoadingMorePreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryLoadingPreview
 import io.github.xexanos.ratatoskr.ui.nowplaying.NowPlayingEmptyPreview
 import io.github.xexanos.ratatoskr.ui.nowplaying.NowPlayingPausedPreview
@@ -79,6 +81,8 @@ class AccessibilityChecksTest {
     @Test fun libraryLoaded() = runChecks { LibraryLoadedPreview() }
     @Test fun libraryEmpty() = runChecks { LibraryEmptyPreview() }
     @Test fun libraryLoading() = runChecks { LibraryLoadingPreview() }
+    @Test fun libraryLoadingMore() = runChecks { LibraryLoadingMorePreview() }
+    @Test fun libraryLoadMoreFailed() = runChecks { LibraryLoadMoreFailedPreview() }
     @Test fun speakersLoaded() = runChecks { SpeakersLoadedPreview() }
     @Test fun speakersEmpty() = runChecks { SpeakersEmptyPreview() }
     @Test fun speakersLoading() = runChecks { SpeakersLoadingPreview() }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -15,11 +15,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.MusicNote
@@ -37,14 +39,18 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -63,6 +69,7 @@ import io.github.xexanos.ratatoskr.ui.UiTestTags
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
 import io.github.xexanos.ratatoskr.ui.toMessage
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -75,6 +82,11 @@ import kotlin.math.roundToInt
 data class LibraryUiState(
     val loading: Boolean = false,
     val items: List<LibraryItemSummary> = emptyList(),
+    // Cursor for the page after the ones already in `items`; null once the last page is in.
+    val nextCursor: String? = null,
+    val loadingMore: Boolean = false,
+    // The last load-more attempt failed; the footer offers a tap-to-retry instead of a spinner.
+    val loadMoreError: Boolean = false,
     val error: String? = null,
 )
 
@@ -88,20 +100,34 @@ class LibraryViewModel(
 
     private val query = MutableStateFlow<String?>(null)
 
+    // Buffered so a request arriving while a page load is in flight is kept (and coalesced with
+    // any later ones) instead of dropped - the scroll position is still near the end when the
+    // page lands, and the UI's trigger won't fire again until the threshold is crossed anew.
+    private val loadMoreRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     init {
         // One search pipeline for the whole screen: the initial (null) load runs immediately,
         // keystrokes are debounced, identical queries are ignored, and collectLatest cancels an
         // in-flight request when a newer query arrives so results can't land out of order.
+        // Follow-up pages are collected INSIDE the same block, so they always belong to the
+        // current query and die with it - a stale cursor can never append to fresh results.
         viewModelScope.launch {
             query
                 .debounce { if (it == null) 0L else SEARCH_DEBOUNCE_MS }
                 .distinctUntilChanged()
-                .collectLatest { load(it) }
+                .collectLatest { q ->
+                    load(q)
+                    loadMoreRequests.collect { loadNextPage(q) }
+                }
         }
     }
 
     fun search(query: String) {
         this.query.value = query.ifBlank { null }
+    }
+
+    fun loadMore() {
+        loadMoreRequests.tryEmit(Unit)
     }
 
     private suspend fun load(query: String?) {
@@ -112,8 +138,26 @@ class LibraryViewModel(
             return
         }
         _uiState.value = when (val result = client.listLibraryItems(query = query)) {
-            is ApiResult.Success -> LibraryUiState(items = result.data.items)
+            is ApiResult.Success ->
+                LibraryUiState(items = result.data.items, nextCursor = result.data.nextCursor)
             is ApiResult.Failure -> LibraryUiState(error = result.error.toMessage())
+        }
+    }
+
+    private suspend fun loadNextPage(query: String?) {
+        val cursor = _uiState.value.nextCursor ?: return
+        val client = connectionManager.client() ?: return
+        _uiState.value = _uiState.value.copy(loadingMore = true, loadMoreError = false)
+        _uiState.value = when (val result = client.listLibraryItems(query = query, cursor = cursor)) {
+            is ApiResult.Success -> _uiState.value.copy(
+                items = _uiState.value.items + result.data.items,
+                nextCursor = result.data.nextCursor,
+                loadingMore = false,
+            )
+            // Keep the loaded items and the cursor: the footer flips to a tap-to-retry row
+            // instead of replacing a working list with the full-screen error state. Scrolling
+            // back into the trigger zone retries too.
+            is ApiResult.Failure -> _uiState.value.copy(loadingMore = false, loadMoreError = true)
         }
     }
 
@@ -146,17 +190,22 @@ fun LibraryScreen(
             query = it
             viewModel.search(it)
         },
+        onLoadMore = viewModel::loadMore,
         onOpenItem = onOpenItem,
         onOpenNowPlaying = onOpenNowPlaying,
         onOpenSettings = onOpenSettings,
     )
 }
 
+// How many rows before the end of the list the next page is requested.
+private const val LOAD_MORE_THRESHOLD = 8
+
 @Composable
 private fun LibraryContent(
     state: LibraryUiState,
     query: String,
     onQueryChange: (String) -> Unit,
+    onLoadMore: () -> Unit = {},
     onOpenItem: (String) -> Unit,
     onOpenNowPlaying: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -219,13 +268,62 @@ private fun LibraryContent(
 
             state.items.isEmpty() -> EmptyLibrary(query)
 
-            else -> LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(top = 16.dp, bottom = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(state.items, key = { it.id }) { item ->
-                    LibraryRow(item, onClick = { onOpenItem(item.id) })
+            else -> {
+                val listState = rememberLazyListState()
+                // Ask for the next page a few rows before the end, so it is usually there by
+                // the time the user reaches it. derivedStateOf keeps this from recomposing on
+                // every scroll frame: it only changes when the threshold is crossed.
+                val nearEnd by remember(listState) {
+                    derivedStateOf {
+                        val info = listState.layoutInfo
+                        val last = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+                        last >= info.totalItemsCount - 1 - LOAD_MORE_THRESHOLD
+                    }
+                }
+                LaunchedEffect(nearEnd, state.nextCursor) {
+                    if (nearEnd && state.nextCursor != null) onLoadMore()
+                }
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(top = 16.dp, bottom = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(state.items, key = { it.id }) { item ->
+                        LibraryRow(item, onClick = { onOpenItem(item.id) })
+                    }
+                    if (state.nextCursor != null) {
+                        item(key = "load-more") {
+                            if (state.loadMoreError) {
+                                Box(
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .heightIn(min = 48.dp)
+                                        .clickable(onClick = onLoadMore)
+                                        .padding(vertical = 12.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Text(
+                                        stringResource(R.string.library_load_more_failed),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        textAlign = TextAlign.Center,
+                                    )
+                                }
+                            } else {
+                                val loadingDesc = stringResource(R.string.library_loading_more)
+                                Box(
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 16.dp)
+                                        .semantics { contentDescription = loadingDesc },
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator()
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -369,6 +467,36 @@ internal fun LibraryEmptyPreview() = RatatoskrTheme {
     Surface {
         LibraryContent(
             state = LibraryUiState(items = emptyList()),
+            query = "",
+            onQueryChange = {},
+            onOpenItem = {},
+            onOpenNowPlaying = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Library - loading more", widthDp = 360, heightDp = 800)
+@Composable
+internal fun LibraryLoadingMorePreview() = RatatoskrTheme {
+    Surface {
+        LibraryContent(
+            state = LibraryUiState(items = previewItems, nextCursor = "c2", loadingMore = true),
+            query = "",
+            onQueryChange = {},
+            onOpenItem = {},
+            onOpenNowPlaying = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Library - load more failed", widthDp = 360, heightDp = 800)
+@Composable
+internal fun LibraryLoadMoreFailedPreview() = RatatoskrTheme {
+    Surface {
+        LibraryContent(
+            state = LibraryUiState(items = previewItems, nextCursor = "c2", loadMoreError = true),
             query = "",
             onQueryChange = {},
             onOpenItem = {},

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -149,11 +149,21 @@ class LibraryViewModel(
         val client = connectionManager.client() ?: return
         _uiState.value = _uiState.value.copy(loadingMore = true, loadMoreError = false)
         _uiState.value = when (val result = client.listLibraryItems(query = query, cursor = cursor)) {
-            is ApiResult.Success -> _uiState.value.copy(
-                items = _uiState.value.items + result.data.items,
-                nextCursor = result.data.nextCursor,
-                loadingMore = false,
-            )
+            is ApiResult.Success -> {
+                // Drop ids already loaded before appending: a duplicate id (cursor drift from a
+                // concurrent ABS-side mutation, or a server pagination bug) would otherwise crash
+                // the LazyColumn, whose item key must be unique. If the page brings nothing new,
+                // stop paginating - a server that keeps returning a non-null cursor with no
+                // forward progress would make the near-end trigger re-fire without end.
+                // The list grows unbounded by design for now (no windowing); see issue #65.
+                val seen = _uiState.value.items.mapTo(HashSet(_uiState.value.items.size)) { it.id }
+                val fresh = result.data.items.filter { seen.add(it.id) }
+                _uiState.value.copy(
+                    items = _uiState.value.items + fresh,
+                    nextCursor = if (fresh.isEmpty()) null else result.data.nextCursor,
+                    loadingMore = false,
+                )
+            }
             // Keep the loaded items and the cursor: the footer flips to a tap-to-retry row
             // instead of replacing a working list with the full-screen error state. Scrolling
             // back into the trigger zone retries too.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -34,6 +34,8 @@
     <string name="library_no_results_body">Keine Hörbücher passen zu %1$s. Versuche es mit einer kürzeren Suche.</string>
     <string name="library_finished">Abgeschlossen</string>
     <string name="library_percent">%1$d&#160;%%</string>
+    <string name="library_loading_more">Weitere Hörbücher werden geladen</string>
+    <string name="library_load_more_failed">Weitere Hörbücher konnten nicht geladen werden. Zum Wiederholen tippen.</string>
 
     <!-- Speakers -->
     <string name="speakers_title">Lautsprecher auswählen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="library_no_results_body">No audiobooks match %1$s. Try a shorter search.</string>
     <string name="library_finished">Finished</string>
     <string name="library_percent">%1$d%%</string>
+    <string name="library_loading_more">Loading more audiobooks</string>
+    <string name="library_load_more_failed">Couldn\'t load more audiobooks. Tap to retry.</string>
 
     <!-- Speakers -->
     <string name="speakers_title">Choose a speaker</string>

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -134,6 +134,114 @@ class LibraryViewModelTest {
     }
 
     @Test
+    fun `loadMore follows the cursor and appends the next page`() = runTest(dispatcher) {
+        val receivedCursors = Collections.synchronizedList(mutableListOf<String?>())
+        server.dispatch { request ->
+            val cursor = request.requestUrl?.queryParameter("cursor")
+            receivedCursors += cursor
+            val body = if (cursor == null) {
+                WireFixtures.libraryPageJson(
+                    items = listOf(WireFixtures.libraryItemSummaryJson(id = "i1", title = "page one")),
+                    nextCursor = "c2",
+                )
+            } else {
+                WireFixtures.libraryPageJson(
+                    items = listOf(WireFixtures.libraryItemSummaryJson(id = "i2", title = "page two")),
+                )
+            }
+            MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(body)
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+        assertEquals("c2", viewModel.uiState.value.nextCursor)
+
+        viewModel.loadMore()
+        settleState { viewModel.uiState.value.items.size == 2 }
+
+        assertEquals(listOf(null, "c2"), receivedCursors)
+        assertEquals(listOf("page one", "page two"), viewModel.uiState.value.items.map { it.title })
+        assertEquals(null, viewModel.uiState.value.nextCursor)
+
+        // The last page is in: further loadMore calls must not hit the server again.
+        viewModel.loadMore()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(2, receivedCursors.size)
+    }
+
+    @Test
+    fun `a failing next page keeps the list and flags a retryable error`() = runTest(dispatcher) {
+        var failNextPage = true
+        server.dispatch { request ->
+            val cursor = request.requestUrl?.queryParameter("cursor")
+            if (cursor != null && failNextPage) {
+                MockResponse().setResponseCode(502)
+                    .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
+            } else {
+                MockResponse().setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(
+                        WireFixtures.libraryPageJson(
+                            items = listOf(
+                                WireFixtures.libraryItemSummaryJson(id = "i-$cursor", title = "page after $cursor"),
+                            ),
+                            nextCursor = if (cursor == null) "c2" else null,
+                        ),
+                    )
+            }
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        viewModel.loadMore()
+        settleState { viewModel.uiState.value.loadMoreError }
+
+        // The loaded page survives, the full-screen error stays clear, and the cursor is kept
+        // so the page can be retried.
+        assertEquals(1, viewModel.uiState.value.items.size)
+        assertEquals(null, viewModel.uiState.value.error)
+        assertEquals("c2", viewModel.uiState.value.nextCursor)
+
+        failNextPage = false
+        viewModel.loadMore()
+        settleState { viewModel.uiState.value.items.size == 2 }
+
+        assertTrue(!viewModel.uiState.value.loadMoreError)
+        assertEquals(null, viewModel.uiState.value.nextCursor)
+    }
+
+    @Test
+    fun `a new query restarts pagination from the first page`() = runTest(dispatcher) {
+        server.dispatch { request ->
+            val cursor = request.requestUrl?.queryParameter("cursor")
+            val q = request.requestUrl?.queryParameter("q")
+            MockResponse().setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    WireFixtures.libraryPageJson(
+                        items = listOf(
+                            WireFixtures.libraryItemSummaryJson(id = "$q-$cursor", title = q ?: "all"),
+                        ),
+                        // Every page claims a successor, so the cursor is non-null when the
+                        // query changes - the fresh load must not carry it over.
+                        nextCursor = "next-after-$cursor",
+                    ),
+                )
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+        viewModel.loadMore()
+        settleState { viewModel.uiState.value.items.size == 2 }
+
+        viewModel.search("cat")
+        settleState { viewModel.uiState.value.items.singleOrNull()?.title == "cat" }
+
+        // The cat load starts over: one page, requested without a cursor (id "cat-null").
+        assertEquals("cat-null", viewModel.uiState.value.items.single().id)
+    }
+
+    @Test
     fun `no configured server surfaces a specific error`() = runTest(dispatcher) {
         val store = DataStoreConnectionStore(
             PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) {

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -31,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.util.Collections
+import java.util.concurrent.CountDownLatch
 
 class LibraryViewModelTest {
 
@@ -239,6 +240,58 @@ class LibraryViewModelTest {
 
         // The cat load starts over: one page, requested without a cursor (id "cat-null").
         assertEquals("cat-null", viewModel.uiState.value.items.single().id)
+    }
+
+    @Test
+    fun `a query change cancels an in-flight page load so its stale page never appends`() = runTest(dispatcher) {
+        // The next-page response is held until the test releases it, so the query changes while
+        // loadNextPage is genuinely suspended on the server - the actual race the collectLatest
+        // structure protects against (unlike the test above, which changes query only after the
+        // page has fully landed).
+        val pageBlocked = CountDownLatch(1)
+        server.dispatch { request ->
+            val cursor = request.requestUrl?.queryParameter("cursor")
+            val q = request.requestUrl?.queryParameter("q")
+            receivedQueries += q
+            when {
+                cursor != null -> {
+                    pageBlocked.await()
+                    MockResponse().setResponseCode(200)
+                        .setHeader("Content-Type", "application/json")
+                        .setBody(
+                            WireFixtures.libraryPageJson(
+                                items = listOf(WireFixtures.libraryItemSummaryJson(id = "stale", title = "stale page")),
+                            ),
+                        )
+                }
+                else -> MockResponse().setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(
+                        WireFixtures.libraryPageJson(
+                            items = listOf(WireFixtures.libraryItemSummaryJson(id = "${q}-first", title = q ?: "all")),
+                            nextCursor = if (q == null) "c2" else null,
+                        ),
+                    )
+            }
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.nextCursor == "c2" }
+
+        // Kick off the next page and wait until it is actually in flight (request received,
+        // now parked on the latch), then change the query while it hangs.
+        viewModel.loadMore()
+        settleState { viewModel.uiState.value.loadingMore }
+        viewModel.search("cat")
+        dispatcher.scheduler.advanceTimeBy(301) // clear the 300ms search debounce
+        settleState { viewModel.uiState.value.items.singleOrNull()?.title == "cat" }
+
+        // Release the held page and give it a chance to (wrongly) append.
+        pageBlocked.countDown()
+        repeat(5) { dispatcher.scheduler.advanceUntilIdle(); Thread.sleep(20) }
+
+        // collectLatest cancelled the null-query page load, so its "stale" item never landed.
+        assertEquals(listOf("cat-first"), viewModel.uiState.value.items.map { it.id })
+        assertTrue(viewModel.uiState.value.items.none { it.id == "stale" })
     }
 
     @Test

--- a/fastlane/metadata/android/de-DE/changelogs/10101.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10101.txt
@@ -1,0 +1,1 @@
+Behebt, dass die Bibliothek nur die ersten 50 Hörbücher anzeigte: die Liste lädt beim Scrollen jetzt weitere Seiten nach.

--- a/fastlane/metadata/android/en-US/changelogs/10101.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10101.txt
@@ -1,0 +1,1 @@
+Fix the library showing only the first 50 audiobooks: the list now loads further pages as you scroll.


### PR DESCRIPTION
## Why

Libraries with more than 50 books were silently truncated: `LibraryViewModel.load()` fetched one page of `GET /library/items` (contract default `limit` 50) and dropped `nextCursor`. Search results past 50 matches were cut off the same way.

## What

- **Infinite scroll**: a `derivedStateOf` scroll trigger requests the next page 8 rows before the end of the LazyColumn; pages are appended with the cursor from the previous response.
- **Stale-cursor safety**: follow-up pages are collected *inside* the search pipeline's `collectLatest` block, so changing the query cancels in-flight page loads and a stale cursor can never append to a newer query's results.
- **Footer states** (per ux-review findings): a `CircularProgressIndicator` with a TalkBack `contentDescription` while more pages exist; on a failed page load it flips to a tap-to-retry row (min 48dp touch target) instead of spinning forever — the loaded list is never replaced by the full-screen error. Scrolling back into the trigger zone also retries.
- **Previews + a11y checks**: new `LibraryLoadingMorePreview` / `LibraryLoadMoreFailedPreview`, both registered in `AccessibilityChecksTest`.
- **Strings**: two new strings in en and de.
- **Version bump 1.1.0 → 1.1.1** (versionCode 10101) with fastlane changelogs.

## Tests

- `loadMore follows the cursor and appends the next page` (incl. no request after the last page)
- `a failing next page keeps the list and flags a retryable error` (and retries successfully)
- `a new query restarts pagination from the first page`
- Existing debounce/error tests unchanged and green; `:app:lintDebug` clean.

## ux-review notes

Blocking findings (perpetual spinner after failure, missing a11y semantics) are addressed. Non-blocking leftovers, deliberately not in this PR: the design doc has no section for list-pagination states yet, and the screenshot-golden-test/lint anti-drift layer in CI is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)