### PR TITLE
docs(spec): move the post-v1 backlog to the issue tracker

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -511,36 +511,8 @@ ratatoskr-app/
 
 ## 14. Planned features (post-v1)
 
-Ideas intentionally deferred beyond v1. These are **not commitments** — they are captured so
-the reasoning is not lost and so the v1 design does not *actively prevent* them (section 2).
-Mirrors the server SPEC's section 16 (Planned features); the app-side counterparts are here.
-
-Most of the section 2 "out of scope for v1" items are the natural first post-v1 candidates and
-are not repeated in full: **chapter-navigation UI**, **bookmarks**, **playback-speed control**,
-**sleep timers**, **podcasts**, **multiple simultaneous sessions**, **Ratatoskr-controlled
-multiroom grouping**, and the platform integrations (**widgets, Android Auto, Wear,
-media-session / notification transport controls**). The following are the additional features on
-the radar:
-
-- **Connect to multiple Ratatoskr servers.** For users with Sonos in more than one location, each
-  behind its own Ratatoskr instance. The app would keep a list of trusted servers and let the user
-  switch between them — a natural generalization of today's single stored server + pinned
-  certificate (sections 5 and 6), which already persist one trusted server; this extends the
-  persist layer and the connect flow to several. Needs each server to be identifiable (a stable,
-  admin-set name) so instances can be labelled in the switcher; tracked on the server side too
-  (server SPEC section 16).
-
-- **Multiple simultaneous sessions (app side).** v1 reflects exactly one active session (section 2).
-  If the server later holds a session per user/speaker (server SPEC section 16), the now-playing
-  experience would show and switch between concurrent sessions rather than assuming a single one —
-  e.g. a session list, or per-speaker now-playing.
-
-- **Cover art.** The library projection carries no cover URL today. Once the server serves cover
-  images (server SPEC section 16), show artwork in the library and now-playing views.
-
-- **Server auto-discovery on the LAN (mDNS/Zeroconf).** Mirrors the server-side feature (server
-  SPEC section 16): instead of the user typing the server's URL by hand on first connect
-  (sections 5 and 6), the app would browse for Ratatoskr instances advertised via mDNS/Bonjour and
-  offer them as selectable candidates. The existing trust-on-first-use certificate-fingerprint
-  confirmation stays mandatory regardless of how the address was obtained, so discovery only
-  removes the typing, not the trust step.
+Post-v1 ideas live in the [issue tracker](https://github.com/Xexanos/ratatoskr-app/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement),
+not in this document, so the backlog sits in one place and each item can be prioritized and
+closed independently. They remain **not commitments** — captured so the reasoning is not lost
+and so the v1 design does not *actively prevent* them (section 2). The server SPEC's section 16
+(Planned features) holds the server-side counterparts.


### PR DESCRIPTION
## Why

SPEC section 14 ("Planned features (post-v1)") kept a hand-maintained list of deferred features. That backlog now overlaps the GitHub issues and duplicates the server-side counterparts in the server SPEC, so it had two homes and would drift.

## What

- Replaces the enumerated list in section 14 with a pointer to the [`enhancement`-labelled issues](https://github.com/Xexanos/ratatoskr-app/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement). The framing (not commitments; don't architect against them; server SPEC section 16 holds the server counterparts) is kept.
- Every deferred item from the old section 14 is now its own issue, with the reasoning preserved: #53 (multiple servers), #54 (multiple sessions), #55 (cover art), #56 (LAN auto-discovery), #57 (chapter nav), #58 (bookmarks), #59 (playback speed), #60 (sleep timer), #61 (podcasts), #62 (multiroom grouping), #63 (platform integrations).

## Checked

Nothing references app SPEC section 14 by number — the "section 14" mentions in CLAUDE.md, elsewhere in this SPEC, and the token-rotation proposal all point at the **server** SPEC's section 14 (security/log-redaction), which is untouched. Section 14 is the last section, so no renumbering.

## Note

I left a one-paragraph pointer stub rather than deleting the section outright, so a SPEC reader still finds the roadmap and the server-SPEC cross-reference stays intact. Say the word if you'd rather drop the section entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)