### PR TITLE
docs(proposal): contract sketch for list thumbnails (#55) + continue-listening (#52)

### DIFF
--- a/docs/proposals/library-covers-and-continue-listening.md
+++ b/docs/proposals/library-covers-and-continue-listening.md
@@ -1,0 +1,116 @@
+# Contract proposal: list cover thumbnails + continue-listening ordering
+
+**Status:** draft (app-side). This sketches what the app needs from the server contract for
+issues #55 (covers in the list) and #52 (actively-listened books lead the list, specially
+marked). It drives a change to `ratatoskr-server/contract/openapi.yaml`, which follows the
+server's own versioning rules (server SPEC section 6). Nothing here is built app-side until the
+contract lands — the app is a thin remote.
+
+Both parts are **additive and backward-compatible** (new optional field / new endpoint), so they
+are oasdiff-clean and fit a **minor** contract bump, like the 1.1.0 refresh-token-rotation change.
+They are independent and can ship separately.
+
+## Current contract (for reference)
+
+`GET /library/items` takes `q`, `limit` (≤100, default 50), `cursor` — no ordering control. It
+returns a `LibraryItemPage` (`items` + nullable `nextCursor`). `LibraryItemSummary` already has:
+
+```yaml
+coverUrl:  { type: string, nullable: true, description: "Absolute URL served by Ratatoskr; may require the token." }
+progress:  $ref Progress   # Progress = { positionSeconds: double, isFinished: bool }
+```
+
+So covers are **not** missing, and `progress` already tells the client whether a book is in
+progress. What is missing is (A) a list-sized cover variant and (B) server-side ordering.
+
+---
+
+## Part A — list cover thumbnails (#55)
+
+**Problem.** `coverUrl` is a single full-size cover. Rendering it in every list row is wasteful on
+bandwidth and, on low-end devices (explicitly in scope, see #65), risks large decoded bitmaps. The
+list wants a small, **server-scaled** image; full size is only needed on now-playing.
+
+**Proposed change.** Add an optional `thumbnailUrl` to `LibraryItemSummary`:
+
+```yaml
+thumbnailUrl:
+  type: string
+  nullable: true
+  description: |
+    Absolute URL of a small, server-scaled cover variant for list/grid rows. Full-size
+    artwork is coverUrl. Sizing is the server's concern (thin client).
+```
+
+- The app uses `thumbnailUrl` in library rows and the continue-listening shelf, `coverUrl` on
+  now-playing. If `thumbnailUrl` is null, fall back to `coverUrl`.
+- Scaling stays server-side (thin client). Target roughly a list-row cover at ~3x density
+  (~200 px wide); the exact size is the server's call.
+
+**Alternative considered.** A size/`?w=` query param on the cover URL. Rejected: `coverUrl` is an
+opaque absolute URL to the client, so a second explicit URL keeps the client dumb and the server in
+control of sizing/caching.
+
+---
+
+## Part B — continue-listening ordering (#52)
+
+**Goal.** Books the user is actively listening to (progress present, `positionSeconds > 0`,
+`isFinished == false`) lead the library and are visibly marked — the app-side equivalent of ABS's
+"Continue Listening" shelf.
+
+**What does NOT need the contract.** The *marking* (badge / distinct row) is already derivable
+client-side from the existing `progress` field. No change needed for the visual.
+
+**What needs the server.**
+1. **Ordering.** With cursor pagination the client only ever holds the loaded pages (see #50), so
+   "in-progress first" cannot be done client-side — it must be server-side ordering.
+2. **Recency.** "Most recently listened first" needs a timestamp the projection does not expose
+   today (`Progress` has no `updatedAt`); only the server has ABS's last-update time.
+
+**Proposed change (recommended): a dedicated shelf endpoint.**
+
+```yaml
+/library/continue:
+  get:
+    operationId: listContinueListening
+    summary: Books currently in progress, most-recently-listened first
+    parameters:
+      - name: limit
+        in: query
+        schema: { type: integer, minimum: 1, maximum: 50, default: 20 }
+    responses:
+      "200": { LibraryItemPage or a plain array of LibraryItemSummary }
+```
+
+- Server returns only in-progress items (not finished, position > 0), ordered by ABS recency.
+- Small and bounded; likely no pagination (a shelf, not the whole library).
+- Cleanly decouples the shelf from the browse list, which stays alphabetical and paginated as-is.
+- The app renders this as a section on top of the Library screen; the full list follows unchanged.
+
+**Alternative considered.** A `sort=recent` query param on `/library/items`. Lighter (no new path),
+but it entangles the shelf with the main list's pagination and still needs the server-side recency
+data. The dedicated endpoint mirrors ABS's model and keeps the two concerns separate.
+
+**Optional add-on.** Expose recency for display ("Continue at 3:24 · 2 days ago") by adding an
+optional `updatedAt` (date-time) to `Progress`. Additive; only if the shelf UX wants the timestamp.
+
+---
+
+## App-side consumption (once the contract lands)
+
+- Library rows: `thumbnailUrl` (fallback `coverUrl`); now-playing: `coverUrl`.
+- A "Continue listening" section at the top of the Library screen, fed by `GET /library/continue`.
+- In-progress marking on rows: derived from the existing `progress` (no contract dependency).
+
+## Open questions for the server side
+
+- `/library/continue`: return a `LibraryItemPage` (for symmetry / future paging) or a plain array?
+- Does the shelf want `Progress.updatedAt` for a "last listened" label, or is order enough for v1?
+- Thumbnail size/format policy (a fixed size vs. a couple of buckets); RGB-565-friendly encoding
+  helps low-end decode (#65) but is a server-rendering detail.
+
+## Next step
+
+Take this into `ratatoskr-server` as a contract change (openapi.yaml + server SPEC section 6
+versioning), then regenerate the Kotlin client and build the app side against it.

--- a/docs/proposals/library-covers-and-continue-listening.md
+++ b/docs/proposals/library-covers-and-continue-listening.md
@@ -102,26 +102,36 @@ client-side from the existing `progress` field. No change needed for the visual.
 **Proposed change (recommended): a dedicated shelf endpoint.**
 
 ```yaml
-/library/continue:
+/library/in-progress:
   get:
-    operationId: listContinueListening
+    operationId: listInProgressItems
     summary: Books currently in progress, most-recently-listened first
     parameters:
       - name: limit
         in: query
-        schema: { type: integer, minimum: 1, maximum: 50, default: 20 }
+        required: false
+        schema: { type: integer, minimum: 1, maximum: 50, default: 25 }
     responses:
-      "200": { LibraryItemPage or a plain array of LibraryItemSummary }
+      "200": { $ref: "#/components/schemas/LibraryItemPage" }
 ```
 
+- **Name: `/library/in-progress`** — a self-describing REST noun. ABS's own term is "Continue
+  Listening", but that is a personalized *shelf* served via `/api/libraries/{id}/personalized`,
+  not a REST path — so the vocabulary is ABS's while the path is ours, and a generic name reads
+  clearly without ABS knowledge. (`/library/continue` was verb-y and vague.)
+- **Response = `LibraryItemPage`**, reused for consistency with `/library/items` (same client
+  type and rendering). The shelf returns one complete page — `nextCursor` is null — so the
+  envelope honestly says "that's all". If shelf-level fields are ever needed later, a superset
+  schema (`allOf [LibraryItemPage, { …new optional fields }]`) stays non-breaking and
+  oasdiff-clean; a bare array could never gain a sibling field, which is why it was rejected.
 - Server returns only in-progress items (not finished, position > 0), ordered by ABS recency.
-- Small and bounded; likely no pagination (a shelf, not the whole library).
+- A shelf, not the whole library: bounded by `limit`, so no pagination in practice.
 - Cleanly decouples the shelf from the browse list, which stays alphabetical and paginated as-is.
 - The app renders this as a section on top of the Library screen; the full list follows unchanged.
 
 **Alternative considered.** A `sort=recent` query param on `/library/items`. Lighter (no new path),
 but it entangles the shelf with the main list's pagination and still needs the server-side recency
-data. The dedicated endpoint mirrors ABS's model and keeps the two concerns separate.
+data. The dedicated endpoint keeps the two concerns separate.
 
 **Optional add-on.** Expose recency for display ("Continue at 3:24 · 2 days ago") by adding an
 optional `updatedAt` (date-time) to `Progress`. Additive; only if the shelf UX wants the timestamp.
@@ -132,7 +142,7 @@ optional `updatedAt` (date-time) to `Progress`. Additive; only if the shelf UX w
 
 - Library rows and the shelf: `coverUrl` with `?h=<rowHeightPx>` (a small Coil interceptor sets
   `h` from the resolved row height); now-playing: `coverUrl` at full size (no `h`).
-- A "Continue listening" section at the top of the Library screen, fed by `GET /library/continue`.
+- A "Continue listening" section at the top of the Library screen, fed by `GET /library/in-progress`.
 - In-progress marking on rows: derived from the existing `progress` (no contract dependency).
 
 ## Open questions for the server side
@@ -140,7 +150,6 @@ optional `updatedAt` (date-time) to `Progress`. Additive; only if the shelf UX w
 - Cover buckets: which height buckets does the server clamp `h` to, and does it re-encode
   (JPEG quality/format) for smaller payloads? Delegate `?height=` to ABS vs. scale in Ratatoskr.
 - Confirm the deployed ABS version exposes a `height` parameter on its cover endpoint.
-- `/library/continue`: return a `LibraryItemPage` (for symmetry / future paging) or a plain array?
 - Does the shelf want `Progress.updatedAt` for a "last listened" label, or is order enough for v1?
 
 ## Next step

--- a/docs/proposals/library-covers-and-continue-listening.md
+++ b/docs/proposals/library-covers-and-continue-listening.md
@@ -6,9 +6,9 @@ marked). It drives a change to `ratatoskr-server/contract/openapi.yaml`, which f
 server's own versioning rules (server SPEC section 6). Nothing here is built app-side until the
 contract lands — the app is a thin remote.
 
-Both parts are **additive and backward-compatible** (each adds a new endpoint), so they are
-oasdiff-clean and fit a **minor** contract bump, like the 1.1.0 refresh-token-rotation change.
-They are independent and can ship separately.
+Both parts are **additive and backward-compatible** (new endpoints, plus schema changes that keep
+every existing field), so they are oasdiff-clean and fit a **minor** contract bump, like the 1.1.0
+refresh-token-rotation change. They are independent and can ship separately.
 
 ## Current contract (for reference)
 
@@ -112,22 +112,50 @@ client-side from the existing `progress` field. No change needed for the visual.
         required: false
         schema: { type: integer, minimum: 1, maximum: 50, default: 25 }
     responses:
-      "200": { $ref: "#/components/schemas/LibraryItemPage" }
+      "200": { $ref: "#/components/schemas/LibraryItemList" }
 ```
 
 - **Name: `/library/in-progress`** — a self-describing REST noun. ABS's own term is "Continue
   Listening", but that is a personalized *shelf* served via `/api/libraries/{id}/personalized`,
   not a REST path — so the vocabulary is ABS's while the path is ours, and a generic name reads
   clearly without ABS knowledge. (`/library/continue` was verb-y and vague.)
-- **Response = `LibraryItemPage`**, reused for consistency with `/library/items` (same client
-  type and rendering). The shelf returns one complete page — `nextCursor` is null — so the
-  envelope honestly says "that's all". If shelf-level fields are ever needed later, a superset
-  schema (`allOf [LibraryItemPage, { …new optional fields }]`) stays non-breaking and
-  oasdiff-clean; a bare array could never gain a sibling field, which is why it was rejected.
+- **Response = `LibraryItemList`**, a new base schema holding only the always-present part
+  (`items`). Pagination is the *specialization*, not the default: the browse list adds the cursor
+  on top of the base, so the shelf carries no `nextCursor` at all — instead of a misleading,
+  always-null field that weakly implies "more could come" when it never does. See "Schema
+  hierarchy" below.
 - Server returns only in-progress items (not finished, position > 0), ordered by ABS recency.
-- A shelf, not the whole library: bounded by `limit`, so no pagination in practice.
+- A shelf, not the whole library: bounded by `limit`, so no pagination.
 - Cleanly decouples the shelf from the browse list, which stays alphabetical and paginated as-is.
 - The app renders this as a section on top of the Library screen; the full list follows unchanged.
+
+**Schema hierarchy (base + specialization).** Extract the always-needed part into a base and make
+the paginated list extend it; shelves use the base:
+
+```yaml
+LibraryItemList:              # base — only the always-present part
+  type: object
+  required: [items]
+  properties:
+    items: { type: array, items: { $ref: "#/components/schemas/LibraryItemSummary" } }
+
+LibraryItemPage:             # browse-list specialization = base + cursor
+  allOf:
+    - $ref: "#/components/schemas/LibraryItemList"
+    - type: object
+      properties:
+        nextCursor: { type: string, nullable: true, description: Present when more items are available. }
+```
+
+- Refactoring today's flat `LibraryItemPage` into this `allOf` resolves to the identical
+  `{ items, nextCursor? }`, so `/library/items` is unchanged — **non-breaking, oasdiff-clean**.
+- Future shelves (#51: series, collections, playlists) return `LibraryItemList`, sharing an honest
+  base instead of each carrying a vestigial cursor. A shelf that later needs its own envelope
+  fields extends it again, e.g. `SeriesShelf: allOf [LibraryItemList, { seriesName }]`. The
+  contract already uses this `allOf` pattern (`LibraryItem` extends `LibraryItemSummary`), and the
+  Kotlin generator handles it.
+- If a full paginated in-progress *view* is ever wanted, `/library/in-progress` can switch to
+  `LibraryItemPage` and add a `cursor` param — additive, non-breaking.
 
 **Alternative considered.** A `sort=recent` query param on `/library/items`. Lighter (no new path),
 but it entangles the shelf with the main list's pagination and still needs the server-side recency

--- a/docs/proposals/library-covers-and-continue-listening.md
+++ b/docs/proposals/library-covers-and-continue-listening.md
@@ -1,4 +1,4 @@
-# Contract proposal: list cover thumbnails + continue-listening ordering
+# Contract proposal: cover-proxy endpoint + continue-listening ordering
 
 **Status:** draft (app-side). This sketches what the app needs from the server contract for
 issues #55 (covers in the list) and #52 (actively-listened books lead the list, specially
@@ -6,8 +6,8 @@ marked). It drives a change to `ratatoskr-server/contract/openapi.yaml`, which f
 server's own versioning rules (server SPEC section 6). Nothing here is built app-side until the
 contract lands — the app is a thin remote.
 
-Both parts are **additive and backward-compatible** (new optional field / new endpoint), so they
-are oasdiff-clean and fit a **minor** contract bump, like the 1.1.0 refresh-token-rotation change.
+Both parts are **additive and backward-compatible** (each adds a new endpoint), so they are
+oasdiff-clean and fit a **minor** contract bump, like the 1.1.0 refresh-token-rotation change.
 They are independent and can ship separately.
 
 ## Current contract (for reference)
@@ -20,36 +20,67 @@ coverUrl:  { type: string, nullable: true, description: "Absolute URL served by 
 progress:  $ref Progress   # Progress = { positionSeconds: double, isFinished: bool }
 ```
 
-So covers are **not** missing, and `progress` already tells the client whether a book is in
-progress. What is missing is (A) a list-sized cover variant and (B) server-side ordering.
+`progress` already tells the client whether a book is in progress. Covers, **despite the field,
+are not served yet**: no cover-image path exists among the ten defined paths, and the server does
+not populate `coverUrl` today (it is effectively always null). So the two gaps are (A) a
+cover-proxy endpoint with scaling and (B) server-side ordering.
 
 ---
 
-## Part A — list cover thumbnails (#55)
+## Part A — cover delivery: a size-parameterized cover-proxy endpoint (#55)
 
-**Problem.** `coverUrl` is a single full-size cover. Rendering it in every list row is wasteful on
-bandwidth and, on low-end devices (explicitly in scope, see #65), risks large decoded bitmaps. The
-list wants a small, **server-scaled** image; full size is only needed on now-playing.
+**Current state.** `LibraryItemSummary.coverUrl` exists in the schema (nullable, "served by
+Ratatoskr"), but the server does **not implement cover serving yet** — `coverUrl` is effectively
+always null today, and no cover-image path is defined in the contract. So this is *build new*, not
+*document existing*.
 
-**Proposed change.** Add an optional `thumbnailUrl` to `LibraryItemSummary`:
+**Why `coverUrl` must be a Ratatoskr URL, not ABS.** The phone has no Audiobookshelf credentials
+(the whole projection exists so it never needs them) and is network-isolated to Ratatoskr (ABS may
+sit on a private network it cannot reach). A direct ABS link — or a redirect to ABS — breaks both.
+So Ratatoskr **proxies** covers: it fetches the image from ABS server-side with its own ABS
+credentials and serves it under its own auth (the "may require the token" in the field description).
+
+**Proposed change: a cover-proxy endpoint, scaled by height.**
 
 ```yaml
-thumbnailUrl:
-  type: string
-  nullable: true
-  description: |
-    Absolute URL of a small, server-scaled cover variant for list/grid rows. Full-size
-    artwork is coverUrl. Sizing is the server's concern (thin client).
+/library/items/{itemId}/cover:
+  get:
+    operationId: getLibraryItemCover
+    summary: Cover image for an item, proxied from Audiobookshelf (optionally scaled)
+    parameters:
+      - $ref: "#/components/parameters/ItemId"
+      - name: h
+        in: query
+        description: |
+          Target max height in pixels for a scaled variant. The client sets it from the row
+          height × device density, so low-density devices request fewer pixels and high-density
+          devices more. Omitted = full/original. The server clamps to a small set of buckets.
+        schema: { type: integer, minimum: 1, maximum: 2048 }
+    responses:
+      "200": { description: Image bytes, content: { image/*: {} } }
+      "401": { $ref: Unauthorized }
+      "404": { $ref: NotFound }
+      "502": { $ref: UpstreamError }
 ```
 
-- The app uses `thumbnailUrl` in library rows and the continue-listening shelf, `coverUrl` on
-  now-playing. If `thumbnailUrl` is null, fall back to `coverUrl`.
-- Scaling stays server-side (thin client). Target roughly a list-row cover at ~3x density
-  (~200 px wide); the exact size is the server's call.
+`coverUrl` becomes an absolute URL pointing at this path (server-provided, so the client stays
+dumb); the client appends `?h=<px>` for a scaled variant and omits it for full size on now-playing.
 
-**Alternative considered.** A size/`?w=` query param on the cover URL. Rejected: `coverUrl` is an
-opaque absolute URL to the client, so a second explicit URL keeps the client dumb and the server in
-control of sizing/caching.
+**Scale by height, not width.** Covers are portrait; in a list the row height is the fixed
+dimension and width follows the aspect ratio, so a height target keeps row heights consistent
+across covers of varying ratios. The client requests `h = rowHeightDp × density`, which is what
+makes the result density-correct — low-density devices ask for fewer pixels, exactly as expected.
+
+**Scaling is delegable to ABS.** ABS's own cover endpoint accepts a `height` parameter and scales
+on the fly, so Ratatoskr can pass the client's `h` straight upstream (`?height=`) instead of doing
+image work itself. It should still **cache** the result and **clamp `h` to a few buckets** (e.g.
+nearest of {128, 256, 384, original}) so it neither hammers ABS nor caches unbounded sizes. (Worth
+confirming `height` support against the deployed ABS version.)
+
+**Rejected alternatives.**
+- A fixed `thumbnailUrl` field (one pixel size for every device) — fails the density point above.
+- A direct ABS link or a redirect to ABS — breaks the thin-client / no-ABS-credentials / network
+  isolation model.
 
 ---
 
@@ -99,16 +130,18 @@ optional `updatedAt` (date-time) to `Progress`. Additive; only if the shelf UX w
 
 ## App-side consumption (once the contract lands)
 
-- Library rows: `thumbnailUrl` (fallback `coverUrl`); now-playing: `coverUrl`.
+- Library rows and the shelf: `coverUrl` with `?h=<rowHeightPx>` (a small Coil interceptor sets
+  `h` from the resolved row height); now-playing: `coverUrl` at full size (no `h`).
 - A "Continue listening" section at the top of the Library screen, fed by `GET /library/continue`.
 - In-progress marking on rows: derived from the existing `progress` (no contract dependency).
 
 ## Open questions for the server side
 
+- Cover buckets: which height buckets does the server clamp `h` to, and does it re-encode
+  (JPEG quality/format) for smaller payloads? Delegate `?height=` to ABS vs. scale in Ratatoskr.
+- Confirm the deployed ABS version exposes a `height` parameter on its cover endpoint.
 - `/library/continue`: return a `LibraryItemPage` (for symmetry / future paging) or a plain array?
 - Does the shelf want `Progress.updatedAt` for a "last listened" label, or is order enough for v1?
-- Thumbnail size/format policy (a fixed size vs. a couple of buckets); RGB-565-friendly encoding
-  helps low-end decode (#65) but is a server-rendering detail.
 
 ## Next step
 


### PR DESCRIPTION
## Why

You picked "start a server feature" next. Since the contract is the single source of truth and nothing may be pre-built app-side, this is the **app-side contract sketch** that kicks off the server work for the two highest-value library features.

## What it captures

Grounded in the current `ratatoskr-server/contract/openapi.yaml` (submodule @ 95a2552):

- **Covers (#55) — build new, not just a field.** `coverUrl` exists in the schema but is **not served yet** (unpopulated, and no cover path is defined). Covers must be **proxied by Ratatoskr** (the phone has no ABS credentials and reaches only Ratatoskr — a direct ABS link/redirect is out). Propose a **cover-proxy endpoint `GET /library/items/{id}/cover?h=`**, scaled **by height** (portrait covers, fixed row height), with the scaling **delegated to ABS's own `height` param**; Ratatoskr caches and clamps `h` to buckets. The client requests `h = rowHeightDp × density`, so it's density-correct (low-density → fewer pixels). A fixed `thumbnailUrl` was rejected (one size for all devices).
- **Continue-listening (#52).** The *marking* is already derivable client-side from the existing `progress` — **no contract change for the visual**. Only **ordering** needs the server (pagination blocks client-side sorting; recency isn't in the projection) → propose a dedicated additive `GET /library/continue` shelf endpoint, ordered by ABS recency. `sort=recent` on `/library/items` weighed as the lighter alternative.

Both add a new endpoint, additive / backward-compatible (oasdiff-clean) → a **minor** contract bump like the 1.1.0 token-rotation change, and independently shippable.

## Not in scope here

No app code and no `openapi.yaml` edits — the contract change happens in `ratatoskr-server` under its own SPEC §6 versioning. This doc is the input to that.

## Open questions (in the doc)

Cover height buckets + re-encode policy (delegate to ABS vs. scale in Ratatoskr); confirm ABS exposes a `height` cover param; `/library/continue` shape (page vs array); whether to add `Progress.updatedAt` for a "last listened" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)