### PR TITLE
feat: reload the library (pull-to-refresh + retry on load error)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 10101
-        versionName = "1.1.1"
+        versionCode = 10200
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AccessibilityChecksTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AccessibilityChecksTest.kt
@@ -29,6 +29,7 @@ import io.github.xexanos.ratatoskr.ui.connect.ConnectConfirmPreview
 import io.github.xexanos.ratatoskr.ui.connect.ConnectErrorPreview
 import io.github.xexanos.ratatoskr.ui.connect.ConnectIdlePreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryEmptyPreview
+import io.github.xexanos.ratatoskr.ui.library.LibraryErrorPreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryLoadedPreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryLoadMoreFailedPreview
 import io.github.xexanos.ratatoskr.ui.library.LibraryLoadingMorePreview
@@ -81,6 +82,7 @@ class AccessibilityChecksTest {
     @Test fun libraryLoaded() = runChecks { LibraryLoadedPreview() }
     @Test fun libraryEmpty() = runChecks { LibraryEmptyPreview() }
     @Test fun libraryLoading() = runChecks { LibraryLoadingPreview() }
+    @Test fun libraryError() = runChecks { LibraryErrorPreview() }
     @Test fun libraryLoadingMore() = runChecks { LibraryLoadingMorePreview() }
     @Test fun libraryLoadMoreFailed() = runChecks { LibraryLoadMoreFailedPreview() }
     @Test fun speakersLoaded() = runChecks { SpeakersLoadedPreview() }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -29,14 +29,21 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SearchOff
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -76,6 +83,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -87,8 +96,16 @@ data class LibraryUiState(
     val loadingMore: Boolean = false,
     // The last load-more attempt failed; the footer offers a tap-to-retry instead of a spinner.
     val loadMoreError: Boolean = false,
+    // A pull-to-refresh is reloading over an existing list (drives the pull indicator).
+    val refreshing: Boolean = false,
+    // One-shot message for a refresh that failed while a list was already shown (a snackbar).
+    val refreshError: String? = null,
     val error: String? = null,
 )
+
+// A single reload of the library. `userTriggered` distinguishes a pull-to-refresh / retry (which
+// reloads over an existing list without the full-screen spinner) from a query change.
+private data class Reload(val query: String?, val userTriggered: Boolean)
 
 @OptIn(FlowPreview::class)
 class LibraryViewModel(
@@ -105,20 +122,29 @@ class LibraryViewModel(
     // page lands, and the UI's trigger won't fire again until the threshold is crossed anew.
     private val loadMoreRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
+    // Explicit reload requests (pull-to-refresh, retry-after-error). Buffered so one is kept if
+    // it arrives mid-load and coalesced with any others.
+    private val refreshRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     init {
-        // One search pipeline for the whole screen: the initial (null) load runs immediately,
-        // keystrokes are debounced, identical queries are ignored, and collectLatest cancels an
-        // in-flight request when a newer query arrives so results can't land out of order.
-        // Follow-up pages are collected INSIDE the same block, so they always belong to the
-        // current query and die with it - a stale cursor can never append to fresh results.
+        // One reload pipeline for the whole screen. Two sources feed it, both funnelled through
+        // the same collectLatest so a newer reload cancels any in-flight load or page fetch:
+        //   - query changes: the initial (null) load runs immediately, keystrokes are debounced,
+        //     identical queries ignored.
+        //   - explicit refreshes: reload the CURRENT query, bypassing debounce and NOT swallowed
+        //     by distinctUntilChanged (a refresh of the same query must actually re-fetch).
+        // Follow-up pages are collected INSIDE the block, so they belong to the current reload and
+        // die with it - a stale cursor can never append to fresh results.
         viewModelScope.launch {
-            query
+            val queryChanges = query
                 .debounce { if (it == null) 0L else SEARCH_DEBOUNCE_MS }
                 .distinctUntilChanged()
-                .collectLatest { q ->
-                    load(q)
-                    loadMoreRequests.collect { loadNextPage(q) }
-                }
+                .map { Reload(it, userTriggered = false) }
+            val refreshes = refreshRequests.map { Reload(query.value, userTriggered = true) }
+            merge(queryChanges, refreshes).collectLatest { reload ->
+                load(reload.query, reload.userTriggered)
+                loadMoreRequests.collect { loadNextPage(reload.query) }
+            }
         }
     }
 
@@ -130,8 +156,23 @@ class LibraryViewModel(
         loadMoreRequests.tryEmit(Unit)
     }
 
-    private suspend fun load(query: String?) {
-        _uiState.value = _uiState.value.copy(loading = true, error = null)
+    /** Pull-to-refresh, or retry after a load error: reloads the current query in place. */
+    fun refresh() {
+        refreshRequests.tryEmit(Unit)
+    }
+
+    fun clearRefreshError() {
+        _uiState.value = _uiState.value.copy(refreshError = null)
+    }
+
+    private suspend fun load(query: String?, userTriggered: Boolean = false) {
+        // A user-triggered reload OVER an existing list shows the pull indicator and keeps the
+        // list; everything else (initial load, query change, retry with nothing shown) uses the
+        // full-screen spinner.
+        val showAsRefresh = userTriggered && _uiState.value.items.isNotEmpty()
+        _uiState.value =
+            if (showAsRefresh) _uiState.value.copy(refreshing = true, refreshError = null)
+            else _uiState.value.copy(loading = true, error = null)
         val client = connectionManager.client()
         if (client == null) {
             _uiState.value = LibraryUiState(error = "No server configured.")
@@ -140,7 +181,13 @@ class LibraryViewModel(
         _uiState.value = when (val result = client.listLibraryItems(query = query)) {
             is ApiResult.Success ->
                 LibraryUiState(items = result.data.items, nextCursor = result.data.nextCursor)
-            is ApiResult.Failure -> LibraryUiState(error = result.error.toMessage())
+            is ApiResult.Failure ->
+                if (showAsRefresh) {
+                    // A refresh over an existing list failed: keep the list, report via a snackbar.
+                    _uiState.value.copy(refreshing = false, refreshError = result.error.toMessage())
+                } else {
+                    LibraryUiState(error = result.error.toMessage())
+                }
         }
     }
 
@@ -185,6 +232,7 @@ fun LibraryScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var query by rememberSaveable { mutableStateOf("") }
+    val snackbarHostState = remember { SnackbarHostState() }
 
     // On process-death restore the text field's saved query comes back, but the ViewModel's
     // search flow restarts at null (full library). Re-issue the restored query so the results
@@ -193,34 +241,56 @@ fun LibraryScreen(
         if (query.isNotBlank()) viewModel.search(query)
     }
 
-    LibraryContent(
-        state = state,
-        query = query,
-        onQueryChange = {
-            query = it
-            viewModel.search(it)
-        },
-        onLoadMore = viewModel::loadMore,
-        onOpenItem = onOpenItem,
-        onOpenNowPlaying = onOpenNowPlaying,
-        onOpenSettings = onOpenSettings,
-    )
+    // A refresh that failed while the list stayed on screen: a one-shot snackbar that keeps the
+    // list AND offers retry as its action (errors always offer retry first).
+    val refreshError = state.refreshError
+    val retryLabel = stringResource(R.string.library_retry)
+    LaunchedEffect(refreshError) {
+        if (refreshError != null) {
+            val result = snackbarHostState.showSnackbar(
+                message = refreshError,
+                actionLabel = retryLabel,
+            )
+            viewModel.clearRefreshError()
+            if (result == SnackbarResult.ActionPerformed) viewModel.refresh()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+        LibraryContent(
+            state = state,
+            query = query,
+            onQueryChange = {
+                query = it
+                viewModel.search(it)
+            },
+            onLoadMore = viewModel::loadMore,
+            onRefresh = viewModel::refresh,
+            onOpenItem = onOpenItem,
+            onOpenNowPlaying = onOpenNowPlaying,
+            onOpenSettings = onOpenSettings,
+            modifier = Modifier.padding(padding),
+        )
+    }
 }
 
 // How many rows before the end of the list the next page is requested.
 private const val LOAD_MORE_THRESHOLD = 8
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryContent(
     state: LibraryUiState,
     query: String,
     onQueryChange: (String) -> Unit,
     onLoadMore: () -> Unit = {},
+    onRefresh: () -> Unit = {},
     onOpenItem: (String) -> Unit,
     onOpenNowPlaying: () -> Unit,
     onOpenSettings: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+    Column(modifier = modifier.fillMaxSize().padding(horizontal = 16.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -268,12 +338,20 @@ private fun LibraryContent(
             }
 
             state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(
-                    state.error,
-                    color = MaterialTheme.colorScheme.error,
-                    textAlign = TextAlign.Center,
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.padding(24.dp),
-                )
+                ) {
+                    Text(
+                        state.error,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Button(onClick = onRefresh) {
+                        Text(stringResource(R.string.library_retry))
+                    }
+                }
             }
 
             state.items.isEmpty() -> EmptyLibrary(query)
@@ -293,43 +371,49 @@ private fun LibraryContent(
                 LaunchedEffect(nearEnd, state.nextCursor) {
                     if (nearEnd && state.nextCursor != null) onLoadMore()
                 }
-                LazyColumn(
-                    state = listState,
+                PullToRefreshBox(
+                    isRefreshing = state.refreshing,
+                    onRefresh = onRefresh,
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(top = 16.dp, bottom = 24.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(state.items, key = { it.id }) { item ->
-                        LibraryRow(item, onClick = { onOpenItem(item.id) })
-                    }
-                    if (state.nextCursor != null) {
-                        item(key = "load-more") {
-                            if (state.loadMoreError) {
-                                Box(
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .heightIn(min = 48.dp)
-                                        .clickable(onClick = onLoadMore)
-                                        .padding(vertical = 12.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    Text(
-                                        stringResource(R.string.library_load_more_failed),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        textAlign = TextAlign.Center,
-                                    )
-                                }
-                            } else {
-                                val loadingDesc = stringResource(R.string.library_loading_more)
-                                Box(
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 16.dp)
-                                        .semantics { contentDescription = loadingDesc },
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator()
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(top = 16.dp, bottom = 24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(state.items, key = { it.id }) { item ->
+                            LibraryRow(item, onClick = { onOpenItem(item.id) })
+                        }
+                        if (state.nextCursor != null) {
+                            item(key = "load-more") {
+                                if (state.loadMoreError) {
+                                    Box(
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .heightIn(min = 48.dp)
+                                            .clickable(onClick = onLoadMore)
+                                            .padding(vertical = 12.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        Text(
+                                            stringResource(R.string.library_load_more_failed),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            textAlign = TextAlign.Center,
+                                        )
+                                    }
+                                } else {
+                                    val loadingDesc = stringResource(R.string.library_loading_more)
+                                    Box(
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 16.dp)
+                                            .semantics { contentDescription = loadingDesc },
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator()
+                                    }
                                 }
                             }
                         }
@@ -522,6 +606,21 @@ internal fun LibraryLoadingPreview() = RatatoskrTheme {
     Surface {
         LibraryContent(
             state = LibraryUiState(loading = true),
+            query = "",
+            onQueryChange = {},
+            onOpenItem = {},
+            onOpenNowPlaying = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Library - error", widthDp = 360, heightDp = 800)
+@Composable
+internal fun LibraryErrorPreview() = RatatoskrTheme {
+    Surface {
+        LibraryContent(
+            state = LibraryUiState(error = "Audiobookshelf is unreachable."),
             query = "",
             onQueryChange = {},
             onOpenItem = {},

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -175,7 +174,11 @@ class LibraryViewModel(
             else _uiState.value.copy(loading = true, error = null)
         val client = connectionManager.client()
         if (client == null) {
-            _uiState.value = LibraryUiState(error = "No server configured.")
+            // Same rule as the failure branch below: a refresh over an existing list keeps the
+            // list and reports via the snackbar rather than wiping to the full-screen error.
+            _uiState.value =
+                if (showAsRefresh) _uiState.value.copy(refreshing = false, refreshError = "No server configured.")
+                else LibraryUiState(error = "No server configured.")
             return
         }
         _uiState.value = when (val result = client.listLibraryItems(query = query)) {
@@ -256,7 +259,11 @@ fun LibraryScreen(
         }
     }
 
-    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+    // No nested Scaffold: MainActivity already hosts the single top-level Scaffold under
+    // enableEdgeToEdge(), so a second one would compute system-bar insets a second time. Host the
+    // snackbar in a Box overlay instead - the content is already inset by the outer Scaffold, so a
+    // bottom-aligned SnackbarHost clears the navigation bar.
+    Box(Modifier.fillMaxSize()) {
         LibraryContent(
             state = state,
             query = query,
@@ -269,8 +276,8 @@ fun LibraryScreen(
             onOpenItem = onOpenItem,
             onOpenNowPlaying = onOpenNowPlaying,
             onOpenSettings = onOpenSettings,
-            modifier = Modifier.padding(padding),
         )
+        SnackbarHost(snackbarHostState, Modifier.align(Alignment.BottomCenter))
     }
 }
 
@@ -288,9 +295,8 @@ private fun LibraryContent(
     onOpenItem: (String) -> Unit,
     onOpenNowPlaying: () -> Unit,
     onOpenSettings: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -36,6 +36,7 @@
     <string name="library_percent">%1$d&#160;%%</string>
     <string name="library_loading_more">Weitere Hörbücher werden geladen</string>
     <string name="library_load_more_failed">Weitere Hörbücher konnten nicht geladen werden. Zum Wiederholen tippen.</string>
+    <string name="library_retry">Erneut versuchen</string>
 
     <!-- Speakers -->
     <string name="speakers_title">Lautsprecher auswählen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="library_percent">%1$d%%</string>
     <string name="library_loading_more">Loading more audiobooks</string>
     <string name="library_load_more_failed">Couldn\'t load more audiobooks. Tap to retry.</string>
+    <string name="library_retry">Try again</string>
 
     <!-- Speakers -->
     <string name="speakers_title">Choose a speaker</string>

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -11,6 +11,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import io.github.xexanos.ratatoskr.data.ConnectionManager
+import io.github.xexanos.ratatoskr.network.FakeConnectionStore
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.persist.DataStoreConnectionStore
@@ -366,6 +367,26 @@ class LibraryViewModelTest {
 
         viewModel.clearRefreshError()
         assertEquals(null, viewModel.uiState.value.refreshError)
+    }
+
+    @Test
+    fun `a refresh that fails because the server became unconfigured keeps the list`() = runTest(dispatcher) {
+        // In-memory store (FakeConnectionStore) so clearing mid-session is synchronous and avoids
+        // the real DataStore's Windows file-rename flakiness. Configured -> load -> clear -> refresh.
+        val store = FakeConnectionStore(baseUrl = server.baseUrl, fingerprint = server.fingerprint)
+        val viewModel = LibraryViewModel(ConnectionManager(store, FakeTokenAccess()))
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        store.clear() // the server becomes unconfigured mid-session
+        viewModel.refresh()
+        settleState { viewModel.uiState.value.refreshError != null }
+
+        // Same contract as a network-failed refresh: keep the list, report via the snackbar,
+        // do NOT wipe to the full-screen error.
+        assertEquals(1, viewModel.uiState.value.items.size)
+        assertEquals(null, viewModel.uiState.value.error)
+        assertEquals("No server configured.", viewModel.uiState.value.refreshError)
+        assertTrue(!viewModel.uiState.value.refreshing)
     }
 
     @Test

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -32,6 +32,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 
 class LibraryViewModelTest {
 
@@ -292,6 +293,79 @@ class LibraryViewModelTest {
         // collectLatest cancelled the null-query page load, so its "stale" item never landed.
         assertEquals(listOf("cat-first"), viewModel.uiState.value.items.map { it.id })
         assertTrue(viewModel.uiState.value.items.none { it.id == "stale" })
+    }
+
+    @Test
+    fun `refresh reloads the current query in place`() = runTest(dispatcher) {
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() } // initial (null) load
+
+        viewModel.search("cat")
+        settleState { viewModel.uiState.value.items.singleOrNull()?.title == "cat" }
+        val before = receivedQueries.size
+
+        viewModel.refresh()
+        settleState { receivedQueries.size == before + 1 }
+
+        // Reloaded the SAME query (cat), not reset to the full library.
+        assertEquals("cat", receivedQueries.last())
+        assertEquals("cat", viewModel.uiState.value.items.single().title)
+    }
+
+    @Test
+    fun `retry after a failed load re-issues the load and clears the error`() = runTest(dispatcher) {
+        val failFirst = AtomicBoolean(true)
+        server.dispatch { request ->
+            val q = request.requestUrl?.queryParameter("q")
+            receivedQueries += q
+            if (failFirst.getAndSet(false)) {
+                MockResponse().setResponseCode(502)
+                    .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
+            } else {
+                MockResponse().setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))))
+            }
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.error != null }
+        assertTrue(viewModel.uiState.value.items.isEmpty())
+
+        viewModel.refresh()
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        assertEquals(null, viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `a failed refresh keeps the list and surfaces a one-shot refreshError`() = runTest(dispatcher) {
+        val failNow = AtomicBoolean(false)
+        server.dispatch { request ->
+            val q = request.requestUrl?.queryParameter("q")
+            receivedQueries += q
+            if (failNow.get()) {
+                MockResponse().setResponseCode(502)
+                    .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
+            } else {
+                MockResponse().setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))))
+            }
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        failNow.set(true)
+        viewModel.refresh()
+        settleState { viewModel.uiState.value.refreshError != null }
+
+        // The list survives; the failure is a one-shot, not the full-screen error state.
+        assertEquals(1, viewModel.uiState.value.items.size)
+        assertEquals(null, viewModel.uiState.value.error)
+        assertTrue(!viewModel.uiState.value.refreshing)
+
+        viewModel.clearRefreshError()
+        assertEquals(null, viewModel.uiState.value.refreshError)
     }
 
     @Test

--- a/docs/ux-design.html
+++ b/docs/ux-design.html
@@ -784,6 +784,7 @@
           <li><span class="dnum">2</span><span><b>Every row answers “where was I?”:</b> a progress bar plus time remaining (“4 h 12 min left”). Raw percentages are a server number; time remaining is the user’s question.</span></li>
           <li><span class="dnum">3</span><span><b>Cover placeholders from the brand palette</b> (initials on copper/ash gradients) until the contract delivers cover art — the list looks finished from day one, not broken.</span></li>
           <li><span class="dnum">4</span><span><b>Search as a round M3 search bar</b> directly under the app bar — searching is this screen’s main job next to resuming. Finished books show a green check instead of a full bar.</span></li>
+          <li><span class="dnum">5</span><span><b>Reload is pull-to-refresh, with retry everywhere a load can fail.</b> Swipe down to reload (standard M3 indicator, not the knot loader — it is a short inline wait). A failed first load shows the error state with a “Try again” button; a failed refresh over an existing list keeps the list and offers retry in a snackbar action — retry is always the first offered action.</span></li>
         </ol>
         <div class="delta">
           <span class="dt">Δ vs. current implementation</span>

--- a/fastlane/metadata/android/de-DE/changelogs/10200.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10200.txt
@@ -1,0 +1,1 @@
+Bibliothek durch Herunterziehen aktualisieren, und bei fehlgeschlagenem Laden vom Fehlerbildschirm aus erneut versuchen.

--- a/fastlane/metadata/android/en-US/changelogs/10200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10200.txt
@@ -1,0 +1,1 @@
+Pull down to refresh the library, and retry from the error screen when a load fails.


### PR DESCRIPTION
Closes #68.

## What

- **Pull-to-refresh** on the loaded list (Material 3 `PullToRefreshBox`, standard indicator per the design's motion rule for short inline waits). Reloads the current query in place.
- **Retry on the full-screen error state** — a "Try again" button (fills the pre-existing gap where a failed initial load was unrecoverable).
- **Failed refresh over an existing list** keeps the list and offers **retry as a snackbar action** (not the full-screen error) — retry is always the first offered action.
- ViewModel: one `collectLatest` pipeline funnels query changes *and* explicit refreshes; a refresh reloads the current query, bypassing debounce/`distinctUntilChanged`, and cancels any in-flight load or page fetch.
- New `library_retry` (en + de), `LibraryErrorPreview` registered in the a11y checks, and a **Library reload decision added to `docs/ux-design.html`** so the design stays the contract.
- Version 1.1.1 → 1.2.0 + changelogs.

## Tests

Three new `LibraryViewModelTest` cases: refresh reloads the current query in place; retry after a failed load re-issues it and clears the error; a failed refresh keeps the list and surfaces a one-shot `refreshError`. Existing suite unchanged. `assembleDebug` + `testDebugUnitTest` + `lintDebug` green.

## ux-review

Ran the ux-review agent. Its one blocking finding on this work — the refresh-failure snackbar offered no retry action (violates "retry is always offered") — is **fixed** (snackbar now has a Try-again action). Design-doc line added per its Q-1.

Deferred to their own tickets (pre-existing, out of scope here):
- **#71** — error messages hardcoded in ViewModels (no `Context`), and error states lacking guidance copy.
- **#72** — the woven-knot loader for felt waits is unimplemented app-wide; the full-screen load path still uses a plain spinner.

Still open (program-level, noted before): no screenshot-golden-test / detekt anti-drift layer in CI, and the instrumented a11y suite isn't a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)