### PR TITLE
Cover art in library and now-playing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# Ratatoskr app
+
+Android remote control for the Ratatoskr server: browse the Audiobookshelf library, pick a
+Sonos speaker, control the single active playback session. All domain logic lives on the
+server; the app renders server state.
+
+## Language
+
+### Library
+
+**Browse list**:
+The complete, alphabetically ordered, cursor-paginated library list (`GET /library/items`).
+Always complete — no item is ever removed from it because it appears elsewhere.
+_Avoid_: main list, full list
+
+**Continue-listening shelf**:
+The bounded, most-recently-listened-first set of in-progress books
+(`GET /library/in-progress`), rendered as a vertical section above the browse list. A view
+onto the library, not a partition: shelf books also keep their place in the browse list.
+The primary entry point into the library — resuming a book is the app's main job, so a
+missing shelf is an error state worth reporting, not a cosmetic absence.
+_Avoid_: pinned section, in-progress list
+
+**In progress**:
+A book with progress present, position > 0 and not finished. Defined by the server; the
+app never re-derives shelf membership itself.
+_Avoid_: active, started, listening

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,3 +25,28 @@ _Avoid_: pinned section, in-progress list
 A book with progress present, position > 0 and not finished. Defined by the server; the
 app never re-derives shelf membership itself.
 _Avoid_: active, started, listening
+
+### Covers
+
+**Cover**:
+A book's artwork, always served by the Ratatoskr server's cover proxy under the app's own
+auth - never fetched from Audiobookshelf directly. "No cover" shows as a failed load (404),
+or as a null cover URL once the server implements it; it is never a sentinel value.
+_Avoid_: thumbnail, artwork (as distinct concepts - there is only the cover, at different sizes)
+
+**Cover URL** (`coverUrl`):
+In the app's domain model: the absolute, bearer-authenticated URL a cover is loadable from.
+On the wire the server sends an origin-relative path; resolving it is the wrapper's job, so
+nothing above the wrapper ever sees a relative value.
+
+**Cover bucket**:
+One of the quantized heights {128, 256, 512, 1024} the app requests covers at (`?h=`),
+rounded up from the rendered size and capped at 1024. Surfaces whose rows land in the same
+bucket share one cached image; nothing ever requests an unquantized or original size.
+_Avoid_: thumbnail size, resolution
+
+**Placeholder tile**:
+The title-initial tile shown where a cover would be - identical while a cover loads and
+when none exists, so a coverless book looks finished, not broken. (Its visual design is
+under review: issue #78.)
+_Avoid_: fallback image, error state (it is deliberately not a distinct state)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 10300
-        versionName = "1.3.0"
+        versionCode = 10400
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,10 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.serialization.core)
+    // Cover art (SPEC section 12): Coil 3 with the OkHttp fetcher, fed by core-network's
+    // coversCallFactory so image loads share the TOFU trust and bearer/refresh auth.
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
@@ -98,6 +102,8 @@ dependencies {
     // MockWebServer over HTTPS, reusing the shared HttpsMockServer + wire fixtures.
     androidTestImplementation(testFixtures(project(":core-network")))
     androidTestImplementation(libs.okhttp.mockwebserver)
+    // FakeImageLoaderEngine for the cover-state Compose tests: no network, no flake.
+    androidTestImplementation(libs.coil.test)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/proguard-test-rules.pro
+++ b/app/proguard-test-rules.pro
@@ -10,3 +10,6 @@
 -dontwarn org.codehaus.mojo.animal_sniffer.**
 -dontwarn com.google.auto.value.**
 -dontwarn javax.lang.model.**
+# coil-test's transitive com.google.android.material references appcompat's DrawableWrapper;
+# appcompat is not on the test APK's runtime classpath and no test reaches that code path.
+-dontwarn androidx.appcompat.graphics.drawable.DrawableWrapper

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -29,6 +29,8 @@ import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -169,6 +171,38 @@ class AppFlowTest {
         connectTrustAndSubmitSignIn()
         compose.awaitText(str(R.string.library_empty_title))
         compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW).assertCountEquals(0)
+    }
+
+    @Test
+    fun libraryCoversLoadThroughTheAuthenticatedPinnedStack() {
+        // A library item whose coverUrl is origin-relative, as the server sends it since
+        // contract 1.3.x; the dispatcher's cover route serves a real decodable PNG.
+        val dispatcher = RatatoskrDispatcher(
+            libraryPage = WireFixtures.libraryPageJson(
+                items = listOf(WireFixtures.libraryItemSummaryJson(coverUrl = "/v1/library/items/i1/cover")),
+            ),
+        )
+        useDispatcher(dispatcher)
+        connectTrustAndSubmitSignIn()
+        compose.awaitTag(UiTestTags.LIBRARY_ROW)
+
+        // The row rendered -> Coil resolved the row height and issued the cover request
+        // through the covers stack (TOFU-pinned HTTPS against the mock server's certificate).
+        compose.waitUntil(10_000) { dispatcher.lastCoverRequest != null }
+        val request = dispatcher.lastCoverRequest!!
+
+        // The bearer token rode along on the image request (same token the API calls use)...
+        assertEquals("Bearer a1", request.getHeader("Authorization"))
+        // ...and the height arrived quantized to a bucket, not as raw view pixels.
+        val h = request.requestUrl?.queryParameter("h")?.toIntOrNull()
+        assertTrue("expected a bucketed h, got h=$h", h in listOf(128, 256, 512, 1024))
+
+        // The decoded cover replaced the initials tile (the placeholder lives inside the
+        // clickable row's merged semantics, so search the unmerged tree).
+        compose.waitUntil(10_000) {
+            compose.onAllNodesWithTag(UiTestTags.COVER_PLACEHOLDER, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/CoverImageTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/CoverImageTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui
+
+import android.content.Context
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.test.FakeImageLoaderEngine
+import io.github.xexanos.ratatoskr.ui.common.CoverImage
+import io.github.xexanos.ratatoskr.ui.common.LocalCoverImageLoader
+import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
+import okhttp3.Call
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+/**
+ * The three visual states of the shared [CoverImage] tile, with a [FakeImageLoaderEngine] (or a
+ * deliberately failing loader) instead of a network: success replaces the initials tile, error
+ * keeps it, a null URL renders it without a loader round-trip. The real network path - auth
+ * header, `?h=` bucket, TOFU stack - is the integration flow's job (AppFlowTest).
+ */
+@RunWith(AndroidJUnit4::class)
+class CoverImageTest {
+
+    @get:Rule val compose = createComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val coverUrl = "https://server.example/v1/library/items/i1/cover"
+
+    private fun setCover(loader: ImageLoader, url: String?) {
+        compose.setContent {
+            RatatoskrTheme {
+                CompositionLocalProvider(LocalCoverImageLoader provides loader) {
+                    CoverImage(title = "The Hobbit", coverUrl = url, modifier = Modifier.size(56.dp))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun loadedCoverReplacesTheInitialsTile() {
+        val engine = FakeImageLoaderEngine.Builder()
+            .intercept({ it is String && it.startsWith(coverUrl) }, ColorImage(Color.Red.toArgb()))
+            .build()
+        val loader = ImageLoader.Builder(context).components { add(engine) }.build()
+
+        setCover(loader, coverUrl)
+
+        compose.waitUntil(5_000) {
+            compose.onAllNodesWithTag(UiTestTags.COVER_PLACEHOLDER).fetchSemanticsNodes().isEmpty()
+        }
+    }
+
+    @Test
+    fun failedLoadKeepsTheInitialsTile() {
+        // A loader whose every call fails - the shape of "no cover" (404), "no server yet",
+        // or a network error. The tile must simply stay; no third visual state.
+        val loader = ImageLoader.Builder(context)
+            .components {
+                add(
+                    OkHttpNetworkFetcherFactory(
+                        callFactory = { Call.Factory { throw IOException("no covers here") } },
+                    ),
+                )
+            }
+            .build()
+
+        setCover(loader, coverUrl)
+
+        compose.waitForIdle()
+        compose.onNodeWithTag(UiTestTags.COVER_PLACEHOLDER).assertExists()
+        compose.onNodeWithText("T").assertExists()
+    }
+
+    @Test
+    fun nullCoverUrlRendersTheTileWithoutAnyRequest() {
+        // An engine with no handlers: any request reaching it would fail the test through
+        // Coil's error path; the null branch must never build a request at all.
+        val engine = FakeImageLoaderEngine.Builder().build()
+        val loader = ImageLoader.Builder(context).components { add(engine) }.build()
+
+        setCover(loader, null)
+
+        compose.onNodeWithTag(UiTestTags.COVER_PLACEHOLDER).assertExists()
+        compose.onNodeWithText("T").assertExists()
+    }
+}

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
@@ -38,12 +38,24 @@ class RatatoskrDispatcher(
     // poll after Stop gets 404, not a revived session.
     @Volatile private var ended = false
 
+    /** The last request the cover route served, for asserting auth and the `?h=` bucket. */
+    @Volatile var lastCoverRequest: RecordedRequest? = null
+        private set
+
     override fun dispatch(request: RecordedRequest): MockResponse {
         val path = request.path.orEmpty().substringBefore('?')
         return when {
             path == "/health" -> jsonResponse("""{"reachable":true}""")
             path == "/v1/auth/login" -> login()
             path == "/v1/speakers" -> jsonResponse(speakers)
+            // The cover proxy: real PNG bytes so Coil decodes and renders them.
+            path.startsWith("/v1/library/items/") && path.endsWith("/cover") -> {
+                lastCoverRequest = request
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "image/png")
+                    .setBody(okio.Buffer().write(COVER_PNG))
+            }
             // A library item tap navigates to the speaker picker, so the item-detail endpoint
             // is not part of the happy path; answer defensively.
             path.startsWith("/v1/library/items/") -> MockResponse().setResponseCode(404)
@@ -84,6 +96,11 @@ class RatatoskrDispatcher(
 
     private companion object {
         val POSITION = Regex(""""positionSeconds"\s*:\s*([0-9.]+)""")
+
+        /** A valid 1x1 PNG - the smallest body Coil can actually decode. */
+        val COVER_PNG: ByteArray = java.util.Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGM4UWHzHwAGBAJ87l7R9AAAAABJRU5ErkJggg==",
+        )
     }
 }
 

--- a/app/src/main/java/io/github/xexanos/ratatoskr/MainActivity.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/MainActivity.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.runtime.CompositionLocalProvider
 import io.github.xexanos.ratatoskr.di.AppContainer
 import io.github.xexanos.ratatoskr.ui.KnotLoader
+import io.github.xexanos.ratatoskr.ui.common.LocalCoverImageLoader
 import io.github.xexanos.ratatoskr.ui.rememberDelayedVisible
 import io.github.xexanos.ratatoskr.ui.navigation.RatatoskrNavHost
 import io.github.xexanos.ratatoskr.ui.navigation.Route
@@ -41,31 +43,33 @@ class MainActivity : ComponentActivity() {
         val container = (application as RatatoskrApp).container
 
         setContent {
-            RatatoskrTheme {
-                Scaffold(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        // Bridges Compose testTags to UiAutomator resource-ids so the
-                        // black-box E2E harness (ratatoskr-e2e, Maestro/UiAutomator) can
-                        // locate the same elements the Compose UI tests find by testTag.
-                        .semantics { testTagsAsResourceId = true },
-                ) { innerPadding ->
-                    Surface(modifier = Modifier.padding(innerPadding)) {
-                        // Resolve the start route off the main thread (see decideStartDestination),
-                        // showing a brief loader instead of blocking onCreate.
-                        var startDestination by remember { mutableStateOf<Route?>(null) }
-                        LaunchedEffect(Unit) {
-                            startDestination = decideStartDestination(container)
-                        }
-                        when (val dest = startDestination) {
-                            // Resolving the start route is normally sub-second; only show the
-                            // loader if it takes long enough to be worth it, so it never flashes.
-                            null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                if (rememberDelayedVisible(active = true)) {
-                                    KnotLoader(label = stringResource(R.string.app_loading))
-                                }
+            CompositionLocalProvider(LocalCoverImageLoader provides container.coverImages.imageLoader) {
+                RatatoskrTheme {
+                    Scaffold(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            // Bridges Compose testTags to UiAutomator resource-ids so the
+                            // black-box E2E harness (ratatoskr-e2e, Maestro/UiAutomator) can
+                            // locate the same elements the Compose UI tests find by testTag.
+                            .semantics { testTagsAsResourceId = true },
+                    ) { innerPadding ->
+                        Surface(modifier = Modifier.padding(innerPadding)) {
+                            // Resolve the start route off the main thread (see decideStartDestination),
+                            // showing a brief loader instead of blocking onCreate.
+                            var startDestination by remember { mutableStateOf<Route?>(null) }
+                            LaunchedEffect(Unit) {
+                                startDestination = decideStartDestination(container)
                             }
-                            else -> RatatoskrNavHost(container = container, startDestination = dest)
+                            when (val dest = startDestination) {
+                                // Resolving the start route is normally sub-second; only show the
+                                // loader if it takes long enough to be worth it, so it never flashes.
+                                null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                    if (rememberDelayedVisible(active = true)) {
+                                        KnotLoader(label = stringResource(R.string.app_loading))
+                                    }
+                                }
+                                else -> RatatoskrNavHost(container = container, startDestination = dest)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightBuckets.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightBuckets.kt
@@ -1,0 +1,30 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.covers
+
+/**
+ * The cover height buckets requested from the server's cover proxy (`?h=`). The server passes
+ * `h` straight to Audiobookshelf's on-the-fly scaler without clamping, so bucket discipline is
+ * the app's job: quantizing to a few sizes keeps any future server/proxy cache effective and
+ * avoids asking ABS for a new scale per device density. Rounded UP so the image is never
+ * upscaled; Coil still decodes down to the actual view size, which is what bounds bitmap
+ * memory on low-end devices.
+ */
+private val COVER_HEIGHT_BUCKETS = intArrayOf(128, 256, 512, 1024)
+
+/**
+ * The bucket for a resolved view height in pixels. Heights above the largest bucket clamp to
+ * it - a deliberate deviation from the contract's "omit h for full size" hint, because an
+ * unclamped original can be 3000x3000 for no visible gain even on the now-playing screen.
+ */
+internal fun coverHeightBucket(heightPx: Int): Int =
+    COVER_HEIGHT_BUCKETS.firstOrNull { heightPx <= it } ?: COVER_HEIGHT_BUCKETS.last()
+
+/** Appends the bucketed height for [heightPx] as the cover proxy's `h` query parameter. */
+internal fun appendCoverHeightParam(url: String, heightPx: Int): String {
+    val separator = if ('?' in url) '&' else '?'
+    return "$url${separator}h=${coverHeightBucket(heightPx)}"
+}

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
@@ -34,10 +34,12 @@ internal class CoverHeightInterceptor : Interceptor {
     }
 
     /**
-     * Only the cover proxy understands `h`; leave any other image URL alone. Matched on the
-     * proxy's path shape rather than a bare `/cover` suffix, so a pass-through absolute URL
-     * from a foreign origin (the wrapper's tolerant-reader case) is not decorated with a
-     * parameter only Ratatoskr defines.
+     * Only the cover proxy understands `h`; leave any other image URL alone. A heuristic on
+     * the proxy's path shape - deliberately host-agnostic, because knowing the server origin
+     * is the wrapper's concern, not this interceptor's. If the server ever returns to sending
+     * absolute URLs (the wrapper's tolerant-reader case), its own covers keep matching; a
+     * foreign URL that happens to share the exact path shape would get one extra query
+     * parameter, which servers ignore.
      */
     private fun isCoverUrl(url: String): Boolean {
         val path = url.substringBefore('?')

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
@@ -1,0 +1,39 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.covers
+
+import coil3.intercept.Interceptor
+import coil3.request.ImageResult
+import coil3.size.Dimension
+
+/**
+ * Appends the bucketed `?h=` parameter to cover requests from the size Coil resolved out of
+ * the layout, so call sites stay dumb: every surface renders `CoverImage` and the right
+ * server-side scale falls out of the composable's measured height (list row, shelf,
+ * now-playing - no per-screen size constants that could drift). An unresolved height
+ * (Dimension.Undefined) leaves the URL untouched, which the server serves as full size.
+ *
+ * Runs before Coil's engine, so the rewritten URL is also the memory/disk cache key: two
+ * surfaces whose heights land in the same bucket share one cached image.
+ */
+internal class CoverHeightInterceptor : Interceptor {
+
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+        val data = chain.request.data
+        val height = chain.size.height
+        if (data !is String || !isCoverUrl(data) || height !is Dimension.Pixels) {
+            return chain.proceed()
+        }
+        val request = chain.request.newBuilder()
+            .data(appendCoverHeightParam(data, height.px))
+            .build()
+        return chain.withRequest(request).proceed()
+    }
+
+    /** Only the cover proxy understands `h`; leave any other image URL alone. */
+    private fun isCoverUrl(url: String): Boolean =
+        url.substringBefore('?').endsWith("/cover")
+}

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
@@ -33,7 +33,14 @@ internal class CoverHeightInterceptor : Interceptor {
         return chain.withRequest(request).proceed()
     }
 
-    /** Only the cover proxy understands `h`; leave any other image URL alone. */
-    private fun isCoverUrl(url: String): Boolean =
-        url.substringBefore('?').endsWith("/cover")
+    /**
+     * Only the cover proxy understands `h`; leave any other image URL alone. Matched on the
+     * proxy's path shape rather than a bare `/cover` suffix, so a pass-through absolute URL
+     * from a foreign origin (the wrapper's tolerant-reader case) is not decorated with a
+     * parameter only Ratatoskr defines.
+     */
+    private fun isCoverUrl(url: String): Boolean {
+        val path = url.substringBefore('?')
+        return path.endsWith("/cover") && path.contains("/library/items/")
+    }
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverImages.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverImages.kt
@@ -9,7 +9,6 @@ import android.content.Context
 import coil3.ImageLoader
 import coil3.disk.DiskCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
-import coil3.request.crossfade
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Call
@@ -65,7 +64,8 @@ class CoverImages(
                 add(OkHttpNetworkFetcherFactory(callFactory = { delegatingCallFactory }))
             }
             .diskCache { diskCache }
-            .crossfade(true)
+            // No loader-wide crossfade: CoverImage sets it per request, where it can honor
+            // the reduced-motion setting (ux-design: motion) - one source of truth.
             .build()
     }
 

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverImages.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverImages.kt
@@ -1,0 +1,77 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.covers
+
+import android.content.Context
+import coil3.ImageLoader
+import coil3.disk.DiskCache
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.request.crossfade
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Call
+import okio.Path.Companion.toOkioPath
+import java.io.IOException
+
+/**
+ * Owns cover-image loading: one app-lifetime Coil [ImageLoader] and its disk cache.
+ *
+ * The loader itself never rebuilds; it follows server/certificate changes through
+ * [currentCallFactory], a per-request delegate to the current [RatatoskrClient]'s
+ * coversCallFactory (TOFU trust + bearer/refresh auth, own dispatcher). A cover request
+ * with no configured client fails that single request - Coil renders the error state,
+ * which is the placeholder tile.
+ *
+ * Caching policy (decided in the #55 design session):
+ * - Disk: 50 MB LRU under cacheDir/covers - over a thousand scaled covers; one long-lived
+ *   [DiskCache] instance, because two loaders on the same directory are not allowed.
+ * - HTTP cache headers are IGNORED (Coil's default): verified against the ABS source, its
+ *   cover endpoint sends no Cache-Control/ETag/Last-Modified on the proxy's request path
+ *   (only `?ts=`-stamped web-client requests get max-age), so "respect headers" would mean
+ *   "never cache". Consequence, accepted for v1: a cover replaced in ABS stays stale here
+ *   until LRU eviction or a manual/sign-out cache clear.
+ * - Memory: Coil's default size (scales with the device's memory class, #65-friendly).
+ * - [clear] wipes both caches: used by sign-out and forget-server (a signed-out device
+ *   keeps no artwork of the library it left) and by the Settings "clear image cache" row.
+ */
+class CoverImages(
+    private val appContext: Context,
+    private val currentCallFactory: () -> Call.Factory?,
+) {
+
+    private val diskCache: DiskCache by lazy {
+        DiskCache.Builder()
+            .directory(appContext.cacheDir.resolve("covers").toOkioPath())
+            .maxSizeBytes(50L * 1024 * 1024)
+            .build()
+    }
+
+    // The fetcher factory memoizes its callFactory lambda, so hand it one stable delegating
+    // factory that re-reads the current client per call - this is what makes a server or
+    // certificate change take effect without rebuilding the loader.
+    private val delegatingCallFactory = Call.Factory { request ->
+        val delegate = currentCallFactory()
+            ?: throw IOException("No server configured; cannot load covers")
+        delegate.newCall(request)
+    }
+
+    val imageLoader: ImageLoader by lazy {
+        ImageLoader.Builder(appContext)
+            .components {
+                add(CoverHeightInterceptor())
+                add(OkHttpNetworkFetcherFactory(callFactory = { delegatingCallFactory }))
+            }
+            .diskCache { diskCache }
+            .crossfade(true)
+            .build()
+    }
+
+    /** Empties the memory and disk caches. DiskCache.clear does file IO - keep it off main. */
+    suspend fun clear() = withContext(Dispatchers.IO) {
+        imageLoader.memoryCache?.clear()
+        diskCache.clear()
+    }
+}

--- a/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
@@ -44,6 +44,15 @@ class ConnectionManager(
 
     fun setSessionActive(active: Boolean) = sessionActive.set(active)
 
+    /**
+     * The already-built client, without building one: a lock-free volatile read. Cover-image
+     * loads resolve their Call.Factory through this per request - by the time any cover URL
+     * exists on screen, the library data that carried it was fetched through [client], so the
+     * cache is populated; before that, a null here simply fails the image request into its
+     * placeholder state.
+     */
+    fun peekClient(): RatatoskrClient? = cached?.client
+
     /** Whether a playback session is currently active - gates client-side token refresh (SPEC section 5). */
     fun isSessionActive(): Boolean = sessionActive.get()
 

--- a/app/src/main/java/io/github/xexanos/ratatoskr/di/AppContainer.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/di/AppContainer.kt
@@ -10,6 +10,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
+import io.github.xexanos.ratatoskr.covers.CoverImages
 import io.github.xexanos.ratatoskr.data.ConnectionManager
 import io.github.xexanos.ratatoskr.network.persist.DataStoreConnectionStore
 import io.github.xexanos.ratatoskr.network.persist.KeystoreCrypto
@@ -35,15 +36,18 @@ class AppContainer(context: Context) {
     val tokenStore = TokenStore(tokenDataStore, KeystoreCrypto())
     val certificateInspector = CertificateInspector()
     val connectionManager = ConnectionManager(connectionStore, tokenStore)
+    val coverImages = CoverImages(appContext) { connectionManager.peekClient()?.coversCallFactory }
 
     /**
-     * Clears all locally persisted state (trusted server + certificate, auth tokens) and drops
-     * the cached client. Lives next to the store declarations so a newly added store is covered
-     * here by construction; used by the instrumented tests to start each from a clean install.
+     * Clears all locally persisted state (trusted server + certificate, auth tokens, cached
+     * cover images) and drops the cached client. Lives next to the store declarations so a
+     * newly added store is covered here by construction; used by the instrumented tests to
+     * start each from a clean install.
      */
     suspend fun reset() {
         connectionStore.clear()
         tokenStore.clear()
         connectionManager.invalidate()
+        coverImages.clear()
     }
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiTestTags.kt
@@ -18,4 +18,5 @@ object UiTestTags {
     const val LIBRARY_ROW = "library_row"
     const val SPEAKER_ROW = "speaker_row"
     const val NOWPLAYING_SEEK = "nowplaying_seek"
+    const val COVER_PLACEHOLDER = "cover_placeholder"
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/common/CoverImage.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/common/CoverImage.kt
@@ -25,8 +25,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
+import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import io.github.xexanos.ratatoskr.ui.UiTestTags
+import io.github.xexanos.ratatoskr.ui.theme.LocalReducedMotion
 
 /**
  * The cover [ImageLoader], provided by the activity from the AppContainer. A CompositionLocal
@@ -56,7 +60,8 @@ fun CoverImage(
     title: String,
     coverUrl: String?,
     modifier: Modifier = Modifier,
-    shape: Shape = MaterialTheme.shapes.medium,
+    // 8 dp - the design's cover-thumbnail radius (ux-design: Shape tokens), shapes.small here.
+    shape: Shape = MaterialTheme.shapes.small,
     initialStyle: TextStyle = MaterialTheme.typography.titleLarge,
     shadowElevation: Dp = 0.dp,
     tonalElevation: Dp = 0.dp,
@@ -73,8 +78,15 @@ fun CoverImage(
             // "no cover" - render the tile without ever issuing a request.
             InitialTile(title, initialStyle)
         } else {
+            // Per-request crossfade instead of the loader-wide default so "remove animations"
+            // is honored: the wait is already communicated by the placeholder tile, so under
+            // reduced motion the cover may simply appear (same convention as the knot loader).
+            val reducedMotion = LocalReducedMotion.current
             SubcomposeAsyncImage(
-                model = coverUrl,
+                model = ImageRequest.Builder(LocalPlatformContext.current)
+                    .data(coverUrl)
+                    .crossfade(!reducedMotion)
+                    .build(),
                 imageLoader = LocalCoverImageLoader.current,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/common/CoverImage.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/common/CoverImage.kt
@@ -1,0 +1,111 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import coil3.compose.SubcomposeAsyncImage
+import io.github.xexanos.ratatoskr.ui.UiTestTags
+
+/**
+ * The cover [ImageLoader], provided by the activity from the AppContainer. A CompositionLocal
+ * instead of Coil's process-wide singleton so UI tests can swap in a FakeImageLoaderEngine
+ * per test, and so the loader's lifecycle stays visible in the container (SPEC section 12).
+ */
+val LocalCoverImageLoader = staticCompositionLocalOf<ImageLoader> {
+    error("No cover ImageLoader provided")
+}
+
+/**
+ * The one cover-art tile every surface renders (library rows today, the continue-listening
+ * shelf of #52 tomorrow, now-playing): the server-scaled cover when it loads, and the title's
+ * initial on a tinted tile before and instead of it. Placeholder and error state are
+ * deliberately identical - "no cover" (a 404 from the proxy) must look finished, not broken,
+ * so a failed load simply keeps the tile (ux-design: placeholders).
+ *
+ * The image is decorative: title and author are adjacent text on every surface, so a content
+ * description would only make TalkBack read everything twice.
+ *
+ * No size parameter: the composable fills whatever [modifier] sizes it to, and the bucketed
+ * `?h=` follows from that measured height via [CoverHeightInterceptor] - callers cannot
+ * introduce drifting size constants.
+ */
+@Composable
+fun CoverImage(
+    title: String,
+    coverUrl: String?,
+    modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.medium,
+    initialStyle: TextStyle = MaterialTheme.typography.titleLarge,
+    shadowElevation: Dp = 0.dp,
+    tonalElevation: Dp = 0.dp,
+) {
+    Surface(
+        modifier = modifier,
+        shape = shape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shadowElevation = shadowElevation,
+        tonalElevation = tonalElevation,
+    ) {
+        if (coverUrl == null) {
+            // The server always sends a cover URL today; null is the contract's documented
+            // "no cover" - render the tile without ever issuing a request.
+            InitialTile(title, initialStyle)
+        } else {
+            SubcomposeAsyncImage(
+                model = coverUrl,
+                imageLoader = LocalCoverImageLoader.current,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                loading = { InitialTile(title, initialStyle) },
+                error = { InitialTile(title, initialStyle) },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun InitialTile(title: String, initialStyle: TextStyle) {
+    val initial = title.trim().firstOrNull()?.uppercase()
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize().testTag(UiTestTags.COVER_PLACEHOLDER),
+    ) {
+        if (initial != null) {
+            Text(
+                text = initial,
+                style = initialStyle,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        } else {
+            Icon(
+                Icons.Default.MusicNote,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
-import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SearchOff
@@ -75,6 +74,7 @@ import io.github.xexanos.ratatoskr.ui.EmptyState
 import io.github.xexanos.ratatoskr.ui.KnotLoader
 import io.github.xexanos.ratatoskr.ui.UiError
 import io.github.xexanos.ratatoskr.ui.UiTestTags
+import io.github.xexanos.ratatoskr.ui.common.CoverImage
 import io.github.xexanos.ratatoskr.ui.rememberDelayedVisible
 import io.github.xexanos.ratatoskr.ui.text
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
@@ -464,7 +464,11 @@ private fun LibraryRow(item: LibraryItemSummary, onClick: () -> Unit) {
             modifier = Modifier.padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            CoverThumb(item.title)
+            CoverImage(
+                title = item.title,
+                coverUrl = item.coverUrl,
+                modifier = Modifier.size(56.dp),
+            )
             Spacer(Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -514,33 +518,6 @@ private fun ProgressLine(progress: Progress?, durationSeconds: Double) {
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        }
-    }
-}
-
-@Composable
-private fun CoverThumb(title: String) {
-    val initial = title.trim().firstOrNull()?.uppercase()
-    Surface(
-        modifier = Modifier.size(56.dp),
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.secondaryContainer,
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            if (initial != null) {
-                Text(
-                    text = initial,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            } else {
-                Icon(
-                    Icons.Default.MusicNote,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/navigation/RatatoskrNavHost.kt
@@ -115,7 +115,9 @@ fun RatatoskrNavHost(container: AppContainer, startDestination: Route) {
 
         composable<Route.Settings> {
             val vm = viewModel<SettingsViewModel>(
-                factory = containerFactory { SettingsViewModel(container.connectionManager) },
+                factory = containerFactory {
+                    SettingsViewModel(container.connectionManager, container.coverImages::clear)
+                },
             )
             SettingsScreen(
                 viewModel = vm,

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/nowplaying/NowPlayingScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
@@ -60,6 +59,7 @@ import io.github.xexanos.ratatoskr.network.domain.LibraryItemSummary
 import io.github.xexanos.ratatoskr.network.domain.PlaybackState
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
 import io.github.xexanos.ratatoskr.network.domain.Session
+import io.github.xexanos.ratatoskr.ui.common.CoverImage
 import io.github.xexanos.ratatoskr.ui.KnotLoader
 import io.github.xexanos.ratatoskr.ui.UiError
 import io.github.xexanos.ratatoskr.ui.UiTestTags
@@ -271,7 +271,7 @@ private fun androidx.compose.foundation.layout.ColumnScope.NowPlayingContent(
     onStop: () -> Unit,
 ) {
     Spacer(Modifier.height(16.dp))
-    CoverArt(title = session.item?.title ?: session.itemId)
+    CoverArt(title = session.item?.title ?: session.itemId, coverUrl = session.item?.coverUrl)
 
     Spacer(Modifier.height(28.dp))
     Text(
@@ -374,34 +374,17 @@ private fun androidx.compose.foundation.layout.ColumnScope.NowPlayingContent(
 }
 
 @Composable
-private fun CoverArt(title: String) {
-    val initial = title.trim().firstOrNull()?.uppercase()
+private fun CoverArt(title: String, coverUrl: String?) {
     Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-        Surface(
+        CoverImage(
+            title = title,
+            coverUrl = coverUrl,
             modifier = Modifier.size(260.dp),
             shape = MaterialTheme.shapes.extraLarge,
-            color = MaterialTheme.colorScheme.secondaryContainer,
+            initialStyle = MaterialTheme.typography.displayLarge,
             shadowElevation = 8.dp,
             tonalElevation = 2.dp,
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                if (initial != null) {
-                    Text(
-                        text = initial,
-                        style = MaterialTheme.typography.displayLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-                } else {
-                    Icon(
-                        Icons.Default.MusicNote,
-                        contentDescription = null,
-                        modifier = Modifier.size(96.dp),
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-                }
-            }
-        }
+        )
     }
 }
 

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
@@ -18,17 +18,21 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -50,10 +54,17 @@ data class SettingsUiState(
     val serverUrl: String? = null,
     val certForgotten: Boolean = false,
     val signedOut: Boolean = false,
+    val imageCacheCleared: Boolean = false,
 )
 
 class SettingsViewModel(
     private val connectionManager: ConnectionManager,
+    /**
+     * Empties the cover caches (CoverImages.clear, injected as a function so this ViewModel
+     * stays JVM-unit-testable). Run on sign-out and forget-server too: a signed-out device
+     * keeps no artwork of the library it left.
+     */
+    private val clearCoverCache: suspend () -> Unit,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -71,6 +82,7 @@ class SettingsViewModel(
         viewModelScope.launch {
             connectionManager.connectionStore.forgetFingerprint()
             connectionManager.invalidate()
+            clearCoverCache()
             _uiState.value = _uiState.value.copy(certForgotten = true)
         }
     }
@@ -78,8 +90,22 @@ class SettingsViewModel(
     fun signOut() {
         viewModelScope.launch {
             connectionManager.tokenStore.clear()
+            clearCoverCache()
             _uiState.value = _uiState.value.copy(signedOut = true)
         }
+    }
+
+    /** Immediate and dialog-free: clearing is lossless, covers simply re-download. */
+    fun clearImageCache() {
+        viewModelScope.launch {
+            clearCoverCache()
+            _uiState.value = _uiState.value.copy(imageCacheCleared = true)
+        }
+    }
+
+    /** Called once the snackbar confirming the clear has been shown. */
+    fun imageCacheClearedShown() {
+        _uiState.value = _uiState.value.copy(imageCacheCleared = false)
     }
 }
 
@@ -90,15 +116,30 @@ fun SettingsScreen(
     onSignedOut: () -> Unit,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val cacheClearedMessage = stringResource(R.string.settings_image_cache_cleared)
 
     LaunchedEffect(state.certForgotten) { if (state.certForgotten) onReTrust() }
     LaunchedEffect(state.signedOut) { if (state.signedOut) onSignedOut() }
+    LaunchedEffect(state.imageCacheCleared) {
+        if (state.imageCacheCleared) {
+            viewModel.imageCacheClearedShown()
+            snackbarHostState.showSnackbar(cacheClearedMessage)
+        }
+    }
 
-    SettingsContent(
-        state = state,
-        onForgetCertificate = viewModel::forgetCertificate,
-        onSignOut = viewModel::signOut,
-    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        SettingsContent(
+            state = state,
+            onForgetCertificate = viewModel::forgetCertificate,
+            onSignOut = viewModel::signOut,
+            onClearImageCache = viewModel::clearImageCache,
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
 }
 
 @Composable
@@ -106,6 +147,7 @@ private fun SettingsContent(
     state: SettingsUiState,
     onForgetCertificate: () -> Unit,
     onSignOut: () -> Unit,
+    onClearImageCache: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
         Text(
@@ -180,6 +222,24 @@ private fun SettingsContent(
         )
 
         Spacer(Modifier.height(32.dp))
+        SectionLabel(stringResource(R.string.settings_section_storage))
+        OutlinedButton(
+            onClick = onClearImageCache,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.settings_clear_image_cache))
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            stringResource(R.string.settings_clear_image_cache_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        Spacer(Modifier.height(32.dp))
         SectionLabel(stringResource(R.string.settings_section_account))
         OutlinedButton(
             onClick = onSignOut,
@@ -216,6 +276,7 @@ internal fun SettingsPreview() = RatatoskrTheme {
             state = SettingsUiState(serverUrl = "https://ratatoskr.home:8080"),
             onForgetCertificate = {},
             onSignOut = {},
+            onClearImageCache = {},
         )
     }
 }
@@ -228,6 +289,7 @@ private fun SettingsUnconfiguredPreview() = RatatoskrTheme {
             state = SettingsUiState(serverUrl = null),
             onForgetCertificate = {},
             onSignOut = {},
+            onClearImageCache = {},
         )
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -71,6 +71,10 @@
     <string name="settings_forget_cert">Zertifikat vergessen und neu vertrauen</string>
     <string name="settings_forget_cert_hint">Entfernt das gepinnte Zertifikat. Bei der nächsten Verbindung bestätigst du den Fingerabdruck des Servers erneut.</string>
     <string name="settings_sign_out">Abmelden</string>
+    <string name="settings_section_storage">Speicher</string>
+    <string name="settings_clear_image_cache">Bilder-Cache leeren</string>
+    <string name="settings_clear_image_cache_hint">Entfernt heruntergeladene Cover. Cover werden bei Bedarf neu geladen — nützlich, wenn sich ein Cover auf dem Server geändert hat.</string>
+    <string name="settings_image_cache_cleared">Bilder-Cache geleert</string>
 
     <!-- Loading -->
     <string name="knot_loader_description">Ladeanzeige: der Ratatoskr-Knoten mit einem Kupfer-Eichhörnchen, das den Strang entlangläuft</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,10 @@
     <string name="settings_forget_cert">Forget certificate and re-trust</string>
     <string name="settings_forget_cert_hint">Removes the pinned certificate. You will confirm the server\'s fingerprint again on the next connection.</string>
     <string name="settings_sign_out">Sign out</string>
+    <string name="settings_section_storage">Storage</string>
+    <string name="settings_clear_image_cache">Clear image cache</string>
+    <string name="settings_clear_image_cache_hint">Removes downloaded cover art. Covers are re-downloaded as needed — use this if a cover changed on the server.</string>
+    <string name="settings_image_cache_cleared">Image cache cleared</string>
 
     <!-- Loading -->
     <string name="knot_loader_description">Loading indicator: the Ratatoskr knot with a copper squirrel running the strand</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,7 +76,7 @@
     <string name="settings_sign_out">Sign out</string>
     <string name="settings_section_storage">Storage</string>
     <string name="settings_clear_image_cache">Clear image cache</string>
-    <string name="settings_clear_image_cache_hint">Removes downloaded cover art. Covers are re-downloaded as needed — use this if a cover changed on the server.</string>
+    <string name="settings_clear_image_cache_hint">Removes downloaded cover art. Covers are re-downloaded as needed; use this if a cover changed on the server.</string>
     <string name="settings_image_cache_cleared">Image cache cleared</string>
 
     <!-- Loading -->

--- a/app/src/minified/keepRules/tests.keep
+++ b/app/src/minified/keepRules/tests.keep
@@ -38,6 +38,14 @@
 -keep class okio.** { *; }
 -keep class androidx.core.** { *; }
 -keep class androidx.collection.** { *; }
+
+# coil-test (androidTest-only, ships in the test APK) hands CoverImageTest a coil3.ColorImage,
+# a coil-core class no app code constructs - R8 would strip it from the app APK. Kept narrowly
+# (not coil3.**) on purpose: the cover-loading path through Coil is NEW release-shape surface,
+# and the minified integration flow exists to validate exactly that under the release keep
+# rules; a wholesale coil3.** keep would exempt it. Widen only if a future coil-test API
+# reaches further unreferenced coil-core classes.
+-keep class coil3.ColorImage { *; }
 -keep class androidx.compose.ui.** { *; }
 -keep class androidx.compose.runtime.** { *; }
 -keep class androidx.activity.** { *; }

--- a/app/src/test/java/io/github/xexanos/ratatoskr/covers/CoverHeightBucketsTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/covers/CoverHeightBucketsTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.covers
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CoverHeightBucketsTest {
+
+    @Test
+    fun `rounds up to the nearest bucket`() {
+        assertEquals(128, coverHeightBucket(1))
+        assertEquals(128, coverHeightBucket(128))
+        assertEquals(256, coverHeightBucket(129))
+        assertEquals(256, coverHeightBucket(256))
+        assertEquals(512, coverHeightBucket(257))
+        assertEquals(512, coverHeightBucket(512))
+        assertEquals(1024, coverHeightBucket(513))
+    }
+
+    @Test
+    fun `caps at the largest bucket instead of requesting the original`() {
+        // Deliberate deviation from the contract's "omit h for full size" hint: an unclamped
+        // original can be 3000x3000 for no visible gain at now-playing size.
+        assertEquals(1024, coverHeightBucket(1024))
+        assertEquals(1024, coverHeightBucket(1025))
+        assertEquals(1024, coverHeightBucket(5000))
+    }
+
+    @Test
+    fun `appends the bucketed height as the h query parameter`() {
+        assertEquals(
+            "https://srv/v1/library/items/42/cover?h=256",
+            appendCoverHeightParam("https://srv/v1/library/items/42/cover", 168),
+        )
+    }
+
+    @Test
+    fun `appends with an ampersand when the url already has a query`() {
+        assertEquals(
+            "https://srv/v1/library/items/42/cover?x=1&h=128",
+            appendCoverHeightParam("https://srv/v1/library/items/42/cover?x=1", 96),
+        )
+    }
+}

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/settings/SettingsViewModelTest.kt
@@ -60,9 +60,13 @@ class SettingsViewModelTest {
         assertEquals("ab:cd:ef", store.fingerprint())
     }
 
+    // Records cover-cache clears so each test can assert the wipe happened (or did not).
+    private var coverCacheClears = 0
+    private val clearCoverCache: suspend () -> Unit = { coverCacheClears++ }
+
     @Test
     fun `initial state reports no configured server`() = runTest(dispatcher) {
-        val viewModel = SettingsViewModel(connectionManager())
+        val viewModel = SettingsViewModel(connectionManager(), clearCoverCache)
 
         assertNull(viewModel.uiState.value.serverUrl)
     }
@@ -71,7 +75,7 @@ class SettingsViewModelTest {
     fun `initial state reports the trusted server's URL`() = runTest(dispatcher) {
         val store = FakeConnectionStore(baseUrl = "https://ratatoskr.home:8080", fingerprint = "ab:cd:ef")
 
-        val viewModel = SettingsViewModel(connectionManager(store))
+        val viewModel = SettingsViewModel(connectionManager(store), clearCoverCache)
 
         assertEquals("https://ratatoskr.home:8080", viewModel.uiState.value.serverUrl)
     }
@@ -79,7 +83,7 @@ class SettingsViewModelTest {
     @Test
     fun `forgetCertificate drops the fingerprint and flips certForgotten`() = runTest(dispatcher) {
         val store = FakeConnectionStore(baseUrl = "https://ratatoskr.home:8080", fingerprint = "ab:cd:ef")
-        val viewModel = SettingsViewModel(connectionManager(store))
+        val viewModel = SettingsViewModel(connectionManager(store), clearCoverCache)
 
         viewModel.forgetCertificate()
 
@@ -87,17 +91,35 @@ class SettingsViewModelTest {
         assertNull(store.fingerprint())
         // The URL is kept for convenience (re-trust flow); only the fingerprint is forgotten.
         assertEquals("https://ratatoskr.home:8080", store.currentServerConfig()?.baseUrl)
+        // A re-trusted server may be a different one; cached covers of the old library go too.
+        assertEquals(1, coverCacheClears)
     }
 
     @Test
     fun `signOut clears the token store and flips signedOut`() = runTest(dispatcher) {
         val tokens = FakeTokenAccess(accessToken = "a1", refreshToken = "r1")
-        val viewModel = SettingsViewModel(connectionManager(tokenStore = tokens))
+        val viewModel = SettingsViewModel(connectionManager(tokenStore = tokens), clearCoverCache)
 
         viewModel.signOut()
 
         assertTrue(viewModel.uiState.value.signedOut)
         assertNull(tokens.currentAccessTokenBlocking())
+        // A signed-out device keeps no artwork of the library it left.
+        assertEquals(1, coverCacheClears)
+    }
+
+    @Test
+    fun `clearImageCache wipes the cover caches and raises the confirmation flag once`() = runTest(dispatcher) {
+        val viewModel = SettingsViewModel(connectionManager(), clearCoverCache)
+
+        viewModel.clearImageCache()
+
+        assertEquals(1, coverCacheClears)
+        assertTrue(viewModel.uiState.value.imageCacheCleared)
+
+        viewModel.imageCacheClearedShown()
+
+        assertEquals(false, viewModel.uiState.value.imageCacheCleared)
     }
 
     private fun realConnectionStore(): ConnectionStore {

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/Mappers.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/Mappers.kt
@@ -45,32 +45,46 @@ internal fun GenSpeaker.toDomain(): Speaker =
 internal fun GenProgress.toDomain(): Progress =
     Progress(positionSeconds = positionSeconds, isFinished = isFinished)
 
-internal fun GenLibraryItemSummary.toDomain(): LibraryItemSummary =
+/**
+ * Resolves the contract's `coverUrl` into a loadable absolute URL. Since contract 1.3.x the
+ * server sends a path relative to its own origin (e.g. `/v1/library/items/{id}/cover`); the
+ * wrapper absorbs that here so the domain model always carries an absolute, bearer-authenticated
+ * URL and no UI code needs to know the server origin. An already-absolute value passes through
+ * untouched (tolerant reader: contract 1.1.0 documented an absolute URL, a future server could
+ * again send one).
+ */
+internal fun resolveCoverUrl(coverUrl: String?, baseUrl: String): String? = when {
+    coverUrl == null -> null
+    coverUrl.startsWith("http://") || coverUrl.startsWith("https://") -> coverUrl
+    else -> baseUrl.trimEnd('/') + (if (coverUrl.startsWith("/")) coverUrl else "/$coverUrl")
+}
+
+internal fun GenLibraryItemSummary.toDomain(baseUrl: String): LibraryItemSummary =
     LibraryItemSummary(
         id = id,
         title = title,
         author = author,
         durationSeconds = durationSeconds,
-        coverUrl = coverUrl,
+        coverUrl = resolveCoverUrl(coverUrl, baseUrl),
         progress = progress?.toDomain(),
     )
 
-internal fun GenLibraryItem.toDomain(): LibraryItem =
+internal fun GenLibraryItem.toDomain(baseUrl: String): LibraryItem =
     LibraryItem(
         summary = LibraryItemSummary(
             id = id,
             title = title,
             author = author,
             durationSeconds = durationSeconds,
-            coverUrl = coverUrl,
+            coverUrl = resolveCoverUrl(coverUrl, baseUrl),
             progress = progress?.toDomain(),
         ),
         description = description,
         narrator = narrator,
     )
 
-internal fun GenLibraryItemPage.toDomain(): LibraryPage =
-    LibraryPage(items = items.map { it.toDomain() }, nextCursor = nextCursor)
+internal fun GenLibraryItemPage.toDomain(baseUrl: String): LibraryPage =
+    LibraryPage(items = items.map { it.toDomain(baseUrl) }, nextCursor = nextCursor)
 
 internal fun GenPlaybackState.toDomain(): PlaybackState = when (this) {
     GenPlaybackState.playing -> PlaybackState.PLAYING
@@ -80,10 +94,10 @@ internal fun GenPlaybackState.toDomain(): PlaybackState = when (this) {
     GenPlaybackState.finished -> PlaybackState.FINISHED
 }
 
-internal fun GenSession.toDomain(): Session =
+internal fun GenSession.toDomain(baseUrl: String): Session =
     Session(
         itemId = itemId,
-        item = item?.toDomain(),
+        item = item?.toDomain(baseUrl),
         speakerId = speakerId,
         state = state.toDomain(),
         positionSeconds = positionSeconds,

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -44,6 +44,15 @@ class RatatoskrClient internal constructor(
     private val playbackApi: PlaybackApi,
     private val tokenStore: TokenAccess,
     private val moshi: Moshi,
+    private val baseUrl: String,
+    /**
+     * OkHttp stack for loading cover images, sharing this client's TLS trust (TOFU pin,
+     * SPEC section 6) and bearer/refresh auth (SPEC section 5) but with its own dispatcher,
+     * so a scroll burst of cover requests can never queue playback commands or the session
+     * poll behind it (OkHttp admission is per-dispatcher, default 5 per host - and covers
+     * share the API's host). Consumed by the app's image loader; closed with [close].
+     */
+    val coversCallFactory: okhttp3.Call.Factory,
     private val closeAction: () -> Unit = {},
 ) {
 
@@ -75,14 +84,14 @@ class RatatoskrClient internal constructor(
         limit: Int? = null,
         cursor: String? = null,
     ): ApiResult<LibraryPage> =
-        execute { libraryApi.listLibraryItems(query, limit, cursor) }.map { it.toDomain() }
+        execute { libraryApi.listLibraryItems(query, limit, cursor) }.map { it.toDomain(baseUrl) }
 
     suspend fun getLibraryItem(itemId: String): ApiResult<LibraryItem> =
-        execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain() }
+        execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain(baseUrl) }
 
     suspend fun currentSession(): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.getCurrentSession() }
-            .adoptingRotatedTokens().map { it.toDomain() }
+            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
 
     /**
      * Starts playback. The stored refresh token is handed to the server so its sync loop can
@@ -93,7 +102,7 @@ class RatatoskrClient internal constructor(
         val refreshToken = tokenStore.refreshToken()
         return execute {
             playbackApi.startSession(StartSessionRequest(itemId, speakerId, refreshToken))
-        }.adoptingRotatedTokens().map { it.toDomain() }
+        }.adoptingRotatedTokens().map { it.toDomain(baseUrl) }
     }
 
     /**
@@ -113,15 +122,15 @@ class RatatoskrClient internal constructor(
 
     suspend fun pause(): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.pauseSession() }
-            .adoptingRotatedTokens().map { it.toDomain() }
+            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
 
     suspend fun resume(): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.resumeSession() }
-            .adoptingRotatedTokens().map { it.toDomain() }
+            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
 
     suspend fun seek(positionSeconds: Double): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.seekSession(SeekRequest(positionSeconds)) }
-            .adoptingRotatedTokens().map { it.toDomain() }
+            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
 
     // --- token adoption -----------------------------------------------------------------
 

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
@@ -122,9 +122,12 @@ object RatatoskrClientFactory {
             .dispatcher(Dispatcher())
             .build()
 
-        // Each OkHttp stack now owns its own dispatcher thread pool; the shared connection pool
-        // (coversClient reuses mainClient's) is evicted once. Release everything when the client
-        // is replaced so it does not linger until GC (SPEC section 13).
+        // Each OkHttp stack owns its own dispatcher thread pool. All three clients share ONE
+        // connection pool (auth/main build from the same baseBuilder, covers via newBuilder),
+        // so two of the three evictAll calls are idempotent repeats - kept uniform per client
+        // on purpose, so the cleanup stays correct if any client ever gets its own pool.
+        // Release everything when the client is replaced so it does not linger until GC
+        // (SPEC section 13).
         val closeAction = {
             for (client in listOf(mainClient, authClient, coversClient)) {
                 client.dispatcher.executorService.shutdown()

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
@@ -112,11 +112,21 @@ object RatatoskrClientFactory {
             .build()
         val mainRetrofit = retrofit(retrofitBase, mainClient, moshi)
 
-        // Each OkHttp stack now owns its own dispatcher thread pool and a connection pool;
-        // release them when the client is replaced so they do not linger until GC (SPEC
-        // section 13).
+        // Cover-image loads share the main client's connection pool (TLS handshakes against a
+        // TOFU-pinned server are not cheap to redo) and its interceptors/authenticator - the
+        // bearer header and the single-flight refresh come along for free - but get their OWN
+        // dispatcher: covers and API calls target the same host, and OkHttp admits only 5
+        // concurrent requests per host per dispatcher, so a scroll burst of cover loads sharing
+        // the main dispatcher would queue play/pause/seek and the session poll behind images.
+        val coversClient = mainClient.newBuilder()
+            .dispatcher(Dispatcher())
+            .build()
+
+        // Each OkHttp stack now owns its own dispatcher thread pool; the shared connection pool
+        // (coversClient reuses mainClient's) is evicted once. Release everything when the client
+        // is replaced so it does not linger until GC (SPEC section 13).
         val closeAction = {
-            for (client in listOf(mainClient, authClient)) {
+            for (client in listOf(mainClient, authClient, coversClient)) {
                 client.dispatcher.executorService.shutdown()
                 client.connectionPool.evictAll()
             }
@@ -129,6 +139,8 @@ object RatatoskrClientFactory {
             playbackApi = mainRetrofit.create(PlaybackApi::class.java),
             tokenStore = tokenStore,
             moshi = moshi,
+            baseUrl = baseUrl,
+            coversCallFactory = coversClient,
             closeAction = closeAction,
         )
     }

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/MappersTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/MappersTest.kt
@@ -8,6 +8,7 @@ package io.github.xexanos.ratatoskr.network.api
 import io.github.xexanos.ratatoskr.network.domain.PlaybackState
 import io.github.xexanos.ratatoskr.network.generated.infrastructure.Serializer
 import io.github.xexanos.ratatoskr.network.generated.model.LibraryItem as GenLibraryItem
+import io.github.xexanos.ratatoskr.network.generated.model.LibraryItemSummary as GenLibraryItemSummary
 import io.github.xexanos.ratatoskr.network.generated.model.PlaybackState as GenPlaybackState
 import io.github.xexanos.ratatoskr.network.generated.model.Progress as GenProgress
 import io.github.xexanos.ratatoskr.network.generated.model.Session as GenSession
@@ -34,7 +35,7 @@ class MappersTest {
             narrator = "Andy Serkis",
         )
 
-        val domain = gen.toDomain()
+        val domain = gen.toDomain(baseUrl = "https://ratatoskr.home:8080")
 
         assertEquals("42", domain.summary.id)
         assertEquals("The Hobbit", domain.summary.title)
@@ -42,6 +43,54 @@ class MappersTest {
         assertEquals(120.5, domain.summary.progress!!.positionSeconds, 0.0)
         assertEquals("There and back again", domain.description)
         assertEquals("Andy Serkis", domain.narrator)
+    }
+
+    // --- coverUrl resolution (contract 1.3.x sends a path relative to the server origin;
+    // --- the wrapper absorbs that so the domain model always carries a loadable URL) --------
+
+    @Test
+    fun `relative coverUrl resolves against the base url`() {
+        assertEquals(
+            "https://ratatoskr.home:8080/v1/library/items/42/cover",
+            resolveCoverUrl("/v1/library/items/42/cover", "https://ratatoskr.home:8080"),
+        )
+    }
+
+    @Test
+    fun `trailing slash on the base url does not double the separator`() {
+        assertEquals(
+            "https://ratatoskr.home:8080/v1/library/items/42/cover",
+            resolveCoverUrl("/v1/library/items/42/cover", "https://ratatoskr.home:8080/"),
+        )
+    }
+
+    @Test
+    fun `absolute coverUrl passes through untouched`() {
+        // Tolerant-reader guard: contract 1.1.0 described the field as an absolute URL, and a
+        // future server could return to that. Never re-prefix an already-absolute value.
+        assertEquals(
+            "https://elsewhere.example/cover.jpg",
+            resolveCoverUrl("https://elsewhere.example/cover.jpg", "https://ratatoskr.home:8080"),
+        )
+    }
+
+    @Test
+    fun `null coverUrl stays null`() {
+        assertEquals(null, resolveCoverUrl(null, "https://ratatoskr.home:8080"))
+    }
+
+    @Test
+    fun `summary mapping resolves the cover url`() {
+        val gen = GenLibraryItemSummary(
+            id = "42",
+            title = "The Hobbit",
+            durationSeconds = 39600.0,
+            coverUrl = "/v1/library/items/42/cover",
+        )
+
+        val domain = gen.toDomain(baseUrl = "https://ratatoskr.home:8080")
+
+        assertEquals("https://ratatoskr.home:8080/v1/library/items/42/cover", domain.coverUrl)
     }
 
     @Test

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -53,6 +53,8 @@ class RatatoskrClientTest {
             playbackApi = retrofit.create(PlaybackApi::class.java),
             tokenStore = tokens,
             moshi = moshi,
+            baseUrl = server.url("/").toString(),
+            coversCallFactory = OkHttpClient(),
         )
     }
 

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
@@ -60,15 +60,21 @@ object WireFixtures {
     fun speakerListJson(vararg speakers: String = arrayOf(speakerJson())): String =
         "[${speakers.joinToString(",")}]"
 
-    /** A single `LibraryItemSummary` wire object (cover/progress omitted - optional). */
+    /**
+     * A single `LibraryItemSummary` wire object (cover/progress omitted by default - both
+     * optional). [coverUrl] is origin-relative on the wire since contract 1.3.x
+     * (e.g. `/v1/library/items/i1/cover`); the client resolves it against its base URL.
+     */
     fun libraryItemSummaryJson(
         id: String = "i1",
         title: String = "The Hobbit",
         author: String? = "J. R. R. Tolkien",
         durationSeconds: Double = 39_600.0,
+        coverUrl: String? = null,
     ): String {
         val a = author?.let { ""","author":"${esc(it)}"""" } ?: ""
-        return """{"id":"${esc(id)}","title":"${esc(title)}"$a,"durationSeconds":$durationSeconds}"""
+        val c = coverUrl?.let { ""","coverUrl":"${esc(it)}"""" } ?: ""
+        return """{"id":"${esc(id)}","title":"${esc(title)}"$a$c,"durationSeconds":$durationSeconds}"""
     }
 
     /** A `GET /v1/library/items` response body (a `LibraryItemPage`). */

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -459,6 +459,19 @@ Decided with the implementing agent. Rationale in brief, so it is not re-litigat
   serialization library is whatever the chosen generator template uses (Moshi for
   `jvm-retrofit2`), configured leniently.
 - **Token storage:** Keystore-backed DataStore (encrypted at rest, section 5).
+- **Cover images:** Coil 3 (`coil-compose` + `coil-network-okhttp`). Apache-2.0 with no
+  Google or proprietary dependencies (F-Droid-safe, section 8); accepts an OkHttp
+  `Call.Factory`, which is exactly the hook for core-network's covers stack (TOFU trust and
+  bearer/refresh auth shared with the API client, but a separate dispatcher so image bursts
+  never queue playback commands) - no generated code touched; multiplatform-ready, matching
+  the KMP door kept open below. One app-lifetime `ImageLoader` owned by the AppContainer and
+  provided to the UI via a CompositionLocal (tests inject coil-test's FakeImageLoaderEngine).
+  Covers are requested server-scaled through quantized height buckets (`?h=` 128/256/512/1024,
+  rounded up from the measured layout size, capped at 1024 even for now-playing). Disk cache:
+  50 MB LRU; HTTP cache headers are deliberately ignored - Audiobookshelf sends none on the
+  proxy's request path, so respecting them would disable caching entirely. Stale covers are
+  the accepted trade-off, bounded by LRU eviction and the Settings "clear image cache" action;
+  sign-out and forget-server wipe the caches.
 - **`minSdk` 26** (Android 8.0): safely covers the Keystore-backed encrypted storage and
   TLS requirements and provides `java.time` (for `Session.updatedAt`) without core-library
   desugaring. Raising coverage to older devices (minSdk 23 + desugaring) is possible but
@@ -481,15 +494,24 @@ ratatoskr-app/
 │   ├── library/             #   browse and search
 │   ├── speakers/            #   speaker picker
 │   ├── nowplaying/          #   play/pause/seek/stop, position display
-│   └── settings/            #   server URL, certificate re-trust/forget, sign-out
+│   ├── settings/            #   server URL, certificate re-trust/forget, sign-out,
+│   │                        #   clear image cache
+│   ├── common/              #   shared composables: CoverImage, the one cover tile every
+│   │                        #   surface renders (list rows, shelves, now-playing)
+│   └── covers/              #   cover-image loading (section 12): the app-lifetime Coil
+│                            #   ImageLoader, the bucketed ?h interceptor, disk cache and
+│                            #   cache clearing
 │
 └── core-network/           # everything that talks to the server; app depends on this
     ├── generated/           #   openapi-generator output - NEVER hand-edited
     ├── api/                 #   thin wrapper over the generated client: maps generated
-    │                        #   DTOs to domain models, absorbs contract changes in one
-    │                        #   place, tolerant to unknown fields; also the bearer/refresh
-    │                        #   interceptors and the single-flight, session-aware refresh
-    │                        #   guard (section 5)
+    │                        #   DTOs to domain models (resolving the origin-relative
+    │                        #   coverUrl to an absolute URL), absorbs contract changes in
+    │                        #   one place, tolerant to unknown fields; also the
+    │                        #   bearer/refresh interceptors, the single-flight,
+    │                        #   session-aware refresh guard (section 5), and the covers
+    │                        #   Call.Factory (shared trust/auth, own dispatcher) the app's
+    │                        #   image loader consumes
     ├── domain/              #   domain models (library item, speaker, session, tokens) and
     │                        #   the ApiResult type — the only types the app module sees
     ├── tls/                 #   TOFU trust manager and certificate-fetch helper (section 6)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -500,7 +500,8 @@ ratatoskr-app/
 │   │                        #   surface renders (list rows, shelves, now-playing)
 │   └── covers/              #   cover-image loading (section 12): the app-lifetime Coil
 │                            #   ImageLoader, the bucketed ?h interceptor, disk cache and
-│                            #   cache clearing
+│                            #   cache clearing. Not a screen: lives beside data/ and di/
+│                            #   in the app module's root package, outside ui/
 │
 └── core-network/           # everything that talks to the server; app depends on this
     ├── generated/           #   openapi-generator output - NEVER hand-edited
@@ -513,7 +514,9 @@ ratatoskr-app/
     │                        #   Call.Factory (shared trust/auth, own dispatcher) the app's
     │                        #   image loader consumes
     ├── domain/              #   domain models (library item, speaker, session, tokens) and
-    │                        #   the ApiResult type — the only types the app module sees
+    │                        #   the ApiResult type — the only server-derived types the app
+    │                        #   module sees (the covers Call.Factory above is the one
+    │                        #   deliberate OkHttp-typed exception, for the image loader)
     ├── tls/                 #   TOFU trust manager and certificate-fetch helper (section 6)
     └── persist/             #   Keystore-backed encrypted token store and the trusted-
                              #   server / fingerprint store (sections 5, 6)

--- a/fastlane/metadata/android/de-DE/changelogs/10400.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10400.txt
@@ -1,0 +1,1 @@
+Bibliothek und Now-Playing zeigen jetzt echte Cover, passend skaliert vom Ratatoskr-Server. Bücher ohne Cover behalten die vertraute Initialen-Kachel, und die Einstellungen erhalten die Aktion „Bilder-Cache leeren".

--- a/fastlane/metadata/android/en-US/changelogs/10400.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10400.txt
@@ -1,0 +1,1 @@
+The library and now-playing screens now show real cover art, served scaled by your Ratatoskr server. Books without a cover keep the familiar initials tile, and Settings gains a "Clear image cache" action.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ datastore = "1.2.1"
 navigationCompose = "2.9.8"
 kotlinxSerialization = "1.11.0"
 jts = "1.20.0"
+coil = "3.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -59,6 +60,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 jts-core = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Closes #55.

## What

The library rows and the now-playing screen now show real cover art, served scaled by the Ratatoskr server's cover proxy (contract 1.3.1, server v1.4.0). Books without a cover keep the title-initial tile, and Settings gains a "Clear image cache" action.

## How

- **Contract bump to 1.3.1** and wrapper absorption: `coverUrl` is origin-relative on the wire since 1.3.x; the mappers resolve it against the client's base URL so the domain model keeps carrying an absolute, bearer-authenticated URL (absolute values pass through — tolerant reader).
- **`coversCallFactory` on `RatatoskrClient`**: shares the main client's TOFU trust, bearer/refresh auth and connection pool, but owns a separate dispatcher so a scroll burst of cover loads can never queue playback commands or the session poll (OkHttp admission is per-dispatcher, same host).
- **Coil 3** (Apache-2.0, no Google dependencies, F-Droid-safe), app module only. One app-lifetime `ImageLoader` that follows server/certificate changes through a per-request delegate; provided via a CompositionLocal so tests inject a `FakeImageLoaderEngine`.
- **Bucketed `?h=`**: a Coil interceptor quantizes the measured layout height to {128, 256, 512, 1024} (rounded up, capped at 1024 — deliberate deviation from the contract's "omit for full size" hint; an unclamped original can be 3000×3000 for no visible gain). Call sites carry no size constants; same-bucket surfaces share one cached image.
- **Caching**: 50 MB disk LRU under `cacheDir/covers`. HTTP cache headers are deliberately ignored — verified against the ABS source: its cover endpoint sends no Cache-Control/ETag/Last-Modified on the proxy's request path, so respecting them would mean never caching. Stale covers are the accepted trade-off, bounded by LRU, the new Settings action, and the cache wipe on sign-out / forget-server (a signed-out device keeps no artwork of the library it left). Server-side follow-ups: Xexanos/ratatoskr-server#98 (null coverUrl when no cover exists), plus a server-owned Cache-Control policy.
- **One shared `CoverImage` composable** (`ui/common`) used by the library and now-playing — the continue-listening shelf (#52, builds on this branch) reuses it as-is. Placeholder and error state are identical by design; the placeholder's visual design is under review in #78.

## Tests

- Unit: coverUrl resolution (relative/absolute/null), bucket boundaries, settings ViewModel incl. cache-clear flows.
- Compose (instrumented): the tile's three states against a fake engine — success replaces the initials tile, failure keeps it, null URL issues no request.
- Integration flow: the cover request carries the bearer token and a bucketed `?h=` through the TOFU-pinned stack, and the decoded PNG replaces the placeholder.
- R8 gates pass (`assembleRelease`, minified androidTest); release APK 1.8 → 1.91 MB. The minified test APK needed one new `-dontwarn` (coil-test's transitive material references appcompat) and a narrow `coil3.ColorImage` keep — kept narrow on purpose so the minified run still validates Coil under the release keep rules.

## Docs

SPEC §12 records Coil 3 with the selection rationale and caching policy; §13 gains `ui/common` and `covers/`; CONTEXT.md defines Cover, Cover URL, Cover bucket and Placeholder tile. Version 1.4.0 (+ fastlane changelogs en-US/de-DE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)