### PR TITLE
docs(ux): add the continue-listening shelf to screen 03

### DIFF
--- a/docs/ux-design.html
+++ b/docs/ux-design.html
@@ -208,6 +208,11 @@
     color: #4F6B35; padding: 16px 16px 6px; flex: none;
   }
   .dark .lib-sec { color: #B5D18B; }
+  /* the shelf sits on a tonal surface band (search-bar container tone) closed by a hairline edge */
+  .shelf-band { background: #F6EAE2; border-bottom: 1px solid #E5D2C4; padding-bottom: 8px; flex: none; }
+  .shelf-band .divider { background: #EBD9CC; }
+  .dark .shelf-band { background: #241914; border-bottom-color: #3A2A22; }
+  .dark .shelf-band .divider { background: #453329; }
   .shelf-err {
     display: flex; gap: 12px; align-items: center; margin: 6px 16px 4px;
     padding: 12px 14px; border-radius: 12px; background: #FFF1EC; border: 1px solid #F3C7BB;
@@ -735,22 +740,24 @@
               <div class="topbar"><div class="tt">Library</div><div class="iconbtn"><svg><use href="#ic-gear"/></svg></div></div>
               <div style="padding: 2px 16px 12px;"><div class="searchbar"><svg><use href="#ic-search"/></svg>Search title or author</div></div>
               <div style="flex:1; overflow:hidden; display:flex; flex-direction:column;">
-                <div class="lib-sec">Continue listening</div>
-                <div class="lrow">
-                  <div class="cover cv-copper">PH</div>
-                  <div class="lmain">
-                    <div class="lt">Project Hail Mary</div>
-                    <div class="la">Andy Weir</div>
-                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:38%"></div></div><span class="plabel">9 h 58 min left</span></div>
+                <div class="shelf-band">
+                  <div class="lib-sec">Continue listening</div>
+                  <div class="lrow">
+                    <div class="cover cv-copper">PH</div>
+                    <div class="lmain">
+                      <div class="lt">Project Hail Mary</div>
+                      <div class="la">Andy Weir</div>
+                      <div class="pline"><div class="ptrack"><div class="pfill" style="width:38%"></div></div><span class="plabel">9 h 58 min left</span></div>
+                    </div>
                   </div>
-                </div>
-                <div class="divider"></div>
-                <div class="lrow">
-                  <div class="cover cv-ash">TH</div>
-                  <div class="lmain">
-                    <div class="lt">The Hobbit</div>
-                    <div class="la">J. R. R. Tolkien</div>
-                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:62%"></div></div><span class="plabel">4 h 12 min left</span></div>
+                  <div class="divider"></div>
+                  <div class="lrow">
+                    <div class="cover cv-ash">TH</div>
+                    <div class="lmain">
+                      <div class="lt">The Hobbit</div>
+                      <div class="la">J. R. R. Tolkien</div>
+                      <div class="pline"><div class="ptrack"><div class="pfill" style="width:62%"></div></div><span class="plabel">4 h 12 min left</span></div>
+                    </div>
                   </div>
                 </div>
                 <div class="lib-sec">All books</div>
@@ -802,12 +809,14 @@
               <div class="topbar"><div class="tt">Library</div><div class="iconbtn"><svg><use href="#ic-gear"/></svg></div></div>
               <div style="padding: 2px 16px 12px;"><div class="searchbar"><svg><use href="#ic-search"/></svg>Search title or author</div></div>
               <div style="flex:1; overflow:hidden; display:flex; flex-direction:column;">
-                <div class="lib-sec">Continue listening</div>
-                <div class="shelf-err">
-                  <svg><use href="#ic-warning"/></svg>
-                  <div class="se-main">
-                    <div class="se-t">Couldn’t load your shelf</div>
-                    <div class="se-a">Tap to retry</div>
+                <div class="shelf-band">
+                  <div class="lib-sec">Continue listening</div>
+                  <div class="shelf-err">
+                    <svg><use href="#ic-warning"/></svg>
+                    <div class="se-main">
+                      <div class="se-t">Couldn’t load your shelf</div>
+                      <div class="se-a">Tap to retry</div>
+                    </div>
                   </div>
                 </div>
                 <div class="lib-sec">All books</div>
@@ -861,7 +870,7 @@
           <li><span class="dnum">3</span><span><b>Search hides the shelf.</b> Search is a query over the whole library; while it is active the shelf disappears and only results show. A “continue listening” section during search would compete with the matches and answer a question the user isn’t asking.</span></li>
           <li><span class="dnum">4</span><span><b>One rule for the shelf slot: data &gt; error row &gt; nothing.</b> If the server returns shelf items, they show; if the shelf load fails, a single inline <b>tap-to-retry row</b> holds the slot (never a blank gap, never a global error — “All books” below still loads); if there are no in-progress books, the slot collapses and “All books” moves up. A missing shelf is a reportable error, not a cosmetic absence.</span></li>
           <li><span class="dnum">5</span><span><b>A mini player instead of a “Now playing” text button.</b> It exists only while a session is active, shows book, speaker and position, offers pause directly, and opens the full Now-playing screen on tap. It feeds off the same <code>getCurrentSession</code> polling — no new route, no new module.</span></li>
-          <li><span class="dnum">6</span><span><b>Every row answers “where was I?”:</b> a progress bar plus time remaining (“4 h 12 min left”). Raw percentages are a server number; time remaining is the user’s question. Shelf rows and browse rows are the same row — identical shape, so the shelf reads as a shortcut into the list, not a different thing.</span></li>
+          <li><span class="dnum">6</span><span><b>Every row answers “where was I?”:</b> a progress bar plus time remaining (“4 h 12 min left”). Raw percentages are a server number; time remaining is the user’s question. Shelf rows and browse rows are the same row — identical shape, so the shelf reads as a shortcut into the list, not a different thing. What tells the sections apart is where a row sits, not how it looks: the shelf rests on a <b>tonal surface band</b> (the search bar’s container tone) closed by a hairline edge, so the boundary stays visible at a glance even mid-scroll.</span></li>
           <li><span class="dnum">7</span><span><b>Covers come from the server’s cover proxy</b> (contract v1.4.0), loaded under the app’s own auth and never fetched from Audiobookshelf directly. A title-initial placeholder tile fills the same slot while a cover loads or when a book has none — so a coverless book looks finished, not broken. One cover tile serves both shelf and browse rows.</span></li>
           <li><span class="dnum">8</span><span><b>Search as a round M3 search bar</b> directly under the app bar — searching is this screen’s main job next to resuming. Finished books show a green check instead of a full bar.</span></li>
           <li><span class="dnum">9</span><span><b>Reload is pull-to-refresh, with retry everywhere a load can fail.</b> Swipe down to reload (standard M3 indicator, not the knot loader — it is a short inline wait). A failed first load shows the error state with a “Try again” button; a failed refresh over an existing list keeps the list and offers retry in a snackbar action — retry is always the first offered action.</span></li>
@@ -869,7 +878,7 @@
         <div class="delta">
           <span class="dt">Δ vs. current implementation</span>
           <ul>
-            <li>A “Continue listening” shelf (most-recently-listened first) now sits above an “All books” header; the browse list keeps every book in place, and a failed shelf load shows an inline retry row instead of blanking the top of the screen.</li>
+            <li>A “Continue listening” shelf (most-recently-listened first) now sits above an “All books” header, on a tonal surface band that visually closes the section; the browse list keeps every book in place, and a failed shelf load shows an inline retry row instead of blanking the top of the screen.</li>
             <li>The text-button row (“Now playing” / “Settings”) is replaced by an M3 top bar with a gear icon plus the mini player.</li>
             <li>List rows gain cover art (server proxy, with the title-initial placeholder tile), progress bars and time remaining instead of a plain text label.</li>
           </ul>

--- a/docs/ux-design.html
+++ b/docs/ux-design.html
@@ -202,6 +202,24 @@
   .done { color: #4F6B35; display: flex; align-items: center; gap: 5px; font-size: 11.5px; font-weight: 600; margin-top: 7px; }
   .done svg { width: 13px; height: 13px; }
 
+  /* library section headers (continue-listening shelf + all-books) and the shelf error slot */
+  .lib-sec {
+    font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+    color: #4F6B35; padding: 16px 16px 6px; flex: none;
+  }
+  .dark .lib-sec { color: #B5D18B; }
+  .shelf-err {
+    display: flex; gap: 12px; align-items: center; margin: 6px 16px 4px;
+    padding: 12px 14px; border-radius: 12px; background: #FFF1EC; border: 1px solid #F3C7BB;
+    color: #872F1F; flex: none;
+  }
+  .shelf-err svg { width: 22px; height: 22px; flex: none; color: #A93B28; }
+  .shelf-err .se-main { flex: 1; min-width: 0; }
+  .shelf-err .se-t { font-size: 13.5px; font-weight: 600; }
+  .shelf-err .se-a { font-size: 12.5px; color: #A93B28; font-weight: 700; margin-top: 1px; }
+  .dark .shelf-err { background: #3A211B; border-color: #5A2E22; color: #FFDAD2; }
+  .dark .shelf-err svg, .dark .shelf-err .se-a { color: #FFB4A3; }
+
   .miniplayer {
     margin: 8px 12px 6px; border-radius: 16px; background: #FFDAD2; color: #3E0400;
     display: flex; align-items: center; gap: 12px; padding: 10px 10px 10px 12px;
@@ -706,7 +724,7 @@
     <div class="section-head">
       <div class="kicker"><span class="no">03 / 06</span><p class="eyebrow" style="margin:0">Library</p></div>
       <h2>The library is home — and carries the active session</h2>
-      <p>There is exactly one active session (SPEC §3). The design takes that seriously: a docked mini player keeps it permanently visible from the library and one tap away.</p>
+      <p>Resuming a book is the app’s main job, so a “Continue listening” shelf leads the screen and the browse list follows below. And because there is exactly one active session (SPEC §3), a docked mini player keeps it permanently visible from the library and one tap away.</p>
     </div>
     <div class="screen-flex">
       <div class="phones">
@@ -717,6 +735,91 @@
               <div class="topbar"><div class="tt">Library</div><div class="iconbtn"><svg><use href="#ic-gear"/></svg></div></div>
               <div style="padding: 2px 16px 12px;"><div class="searchbar"><svg><use href="#ic-search"/></svg>Search title or author</div></div>
               <div style="flex:1; overflow:hidden; display:flex; flex-direction:column;">
+                <div class="lib-sec">Continue listening</div>
+                <div class="lrow">
+                  <div class="cover cv-copper">PH</div>
+                  <div class="lmain">
+                    <div class="lt">Project Hail Mary</div>
+                    <div class="la">Andy Weir</div>
+                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:38%"></div></div><span class="plabel">9 h 58 min left</span></div>
+                  </div>
+                </div>
+                <div class="divider"></div>
+                <div class="lrow">
+                  <div class="cover cv-ash">TH</div>
+                  <div class="lmain">
+                    <div class="lt">The Hobbit</div>
+                    <div class="la">J. R. R. Tolkien</div>
+                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:62%"></div></div><span class="plabel">4 h 12 min left</span></div>
+                  </div>
+                </div>
+                <div class="lib-sec">All books</div>
+                <div class="lrow">
+                  <div class="cover cv-moss">D</div>
+                  <div class="lmain">
+                    <div class="lt">Dune</div>
+                    <div class="la">Frank Herbert</div>
+                    <div class="pline"><div class="ptrack"></div><span class="plabel">21 h 02 min</span></div>
+                  </div>
+                </div>
+                <div class="divider"></div>
+                <div class="lrow">
+                  <div class="cover cv-copper">PH</div>
+                  <div class="lmain">
+                    <div class="lt">Project Hail Mary</div>
+                    <div class="la">Andy Weir</div>
+                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:38%"></div></div><span class="plabel">9 h 58 min left</span></div>
+                  </div>
+                </div>
+                <div class="divider"></div>
+                <div class="lrow">
+                  <div class="cover cv-ash">TH</div>
+                  <div class="lmain">
+                    <div class="lt">The Hobbit</div>
+                    <div class="la">J. R. R. Tolkien</div>
+                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:62%"></div></div><span class="plabel">4 h 12 min left</span></div>
+                  </div>
+                </div>
+              </div>
+              <div class="miniplayer">
+                <div class="mp-progress"></div>
+                <div class="cover cv-copper">PH</div>
+                <div>
+                  <div class="mt">Project Hail Mary</div>
+                  <div class="ms">Playing on Living Room · 6:12:45</div>
+                </div>
+                <div class="mp-btn"><svg><use href="#ic-pause"/></svg></div>
+              </div>
+            </div>
+            <div class="gbar"></div>
+          </div>
+          <p class="phone-cap">Loaded — the shelf sits above “All books”, its books kept in place below</p>
+        </div>
+        <div class="phone-slot">
+          <div class="phone">
+            <div class="sbar"><span>21:47</span><span class="sicons"><svg><use href="#ic-wifi"/></svg><svg><use href="#ic-batt"/></svg></span></div>
+            <div class="body" style="padding-bottom:14px;">
+              <div class="topbar"><div class="tt">Library</div><div class="iconbtn"><svg><use href="#ic-gear"/></svg></div></div>
+              <div style="padding: 2px 16px 12px;"><div class="searchbar"><svg><use href="#ic-search"/></svg>Search title or author</div></div>
+              <div style="flex:1; overflow:hidden; display:flex; flex-direction:column;">
+                <div class="lib-sec">Continue listening</div>
+                <div class="shelf-err">
+                  <svg><use href="#ic-warning"/></svg>
+                  <div class="se-main">
+                    <div class="se-t">Couldn’t load your shelf</div>
+                    <div class="se-a">Tap to retry</div>
+                  </div>
+                </div>
+                <div class="lib-sec">All books</div>
+                <div class="lrow">
+                  <div class="cover cv-moss">D</div>
+                  <div class="lmain">
+                    <div class="lt">Dune</div>
+                    <div class="la">Frank Herbert</div>
+                    <div class="pline"><div class="ptrack"></div><span class="plabel">21 h 02 min</span></div>
+                  </div>
+                </div>
+                <div class="divider"></div>
                 <div class="lrow">
                   <div class="cover cv-copper">PH</div>
                   <div class="lmain">
@@ -743,54 +846,32 @@
                     <div class="done"><svg><use href="#ic-check"/></svg>Finished</div>
                   </div>
                 </div>
-                <div class="divider"></div>
-                <div class="lrow">
-                  <div class="cover cv-moss">D</div>
-                  <div class="lmain">
-                    <div class="lt">Dune</div>
-                    <div class="la">Frank Herbert</div>
-                    <div class="pline"><div class="ptrack"></div><span class="plabel">21 h 02 min</span></div>
-                  </div>
-                </div>
-                <div class="divider"></div>
-                <div class="lrow">
-                  <div class="cover cv-dusk">NW</div>
-                  <div class="lmain">
-                    <div class="lt">The Name of the Wind</div>
-                    <div class="la">Patrick Rothfuss</div>
-                    <div class="pline"><div class="ptrack"><div class="pfill" style="width:15%"></div></div><span class="plabel">23 h 44 min left</span></div>
-                  </div>
-                </div>
-              </div>
-              <div class="miniplayer">
-                <div class="mp-progress"></div>
-                <div class="cover cv-copper">PH</div>
-                <div>
-                  <div class="mt">Project Hail Mary</div>
-                  <div class="ms">Playing on Living Room · 6:12:45</div>
-                </div>
-                <div class="mp-btn"><svg><use href="#ic-pause"/></svg></div>
               </div>
             </div>
             <div class="gbar"></div>
           </div>
-          <p class="phone-cap">Loaded, with the active session in the mini player</p>
+          <p class="phone-cap">Shelf load failed — one inline retry row holds the slot; “All books” is unaffected</p>
         </div>
       </div>
       <div class="decisions">
         <h3>Decisions</h3>
         <ol>
-          <li><span class="dnum">1</span><span><b>A mini player instead of a “Now playing” text button.</b> It exists only while a session is active, shows book, speaker and position, offers pause directly, and opens the full Now-playing screen on tap. It feeds off the same <code>getCurrentSession</code> polling — no new route, no new module.</span></li>
-          <li><span class="dnum">2</span><span><b>Every row answers “where was I?”:</b> a progress bar plus time remaining (“4 h 12 min left”). Raw percentages are a server number; time remaining is the user’s question.</span></li>
-          <li><span class="dnum">3</span><span><b>Cover placeholders from the brand palette</b> (initials on copper/ash gradients) until the contract delivers cover art — the list looks finished from day one, not broken.</span></li>
-          <li><span class="dnum">4</span><span><b>Search as a round M3 search bar</b> directly under the app bar — searching is this screen’s main job next to resuming. Finished books show a green check instead of a full bar.</span></li>
-          <li><span class="dnum">5</span><span><b>Reload is pull-to-refresh, with retry everywhere a load can fail.</b> Swipe down to reload (standard M3 indicator, not the knot loader — it is a short inline wait). A failed first load shows the error state with a “Try again” button; a failed refresh over an existing list keeps the list and offers retry in a snackbar action — retry is always the first offered action.</span></li>
+          <li><span class="dnum">1</span><span><b>A “Continue listening” shelf, vertical, above “All books”.</b> Resuming a book is the app’s main job, so the two-to-three most-recently-listened books sit at the top as a vertical section — <em>not</em> a horizontal carousel, which would hide rows off-screen and break the one-handed top-to-bottom scan the rest of the screen relies on. German headers: <b>“Weiterhören”</b> and <b>“Alle Bücher”</b>.</span></li>
+          <li><span class="dnum">2</span><span><b>The shelf is a view onto the library, not a partition of it.</b> Shelf books keep their alphabetical place in “All books” — no deduplication. Pulling them out would make the complete library look incomplete and shuffle it as progress changes. For the same reason there is <b>no badge</b> marking shelf books in the browse list: the shelf already surfaces them, and a badge would only repeat that.</span></li>
+          <li><span class="dnum">3</span><span><b>Search hides the shelf.</b> Search is a query over the whole library; while it is active the shelf disappears and only results show. A “continue listening” section during search would compete with the matches and answer a question the user isn’t asking.</span></li>
+          <li><span class="dnum">4</span><span><b>One rule for the shelf slot: data &gt; error row &gt; nothing.</b> If the server returns shelf items, they show; if the shelf load fails, a single inline <b>tap-to-retry row</b> holds the slot (never a blank gap, never a global error — “All books” below still loads); if there are no in-progress books, the slot collapses and “All books” moves up. A missing shelf is a reportable error, not a cosmetic absence.</span></li>
+          <li><span class="dnum">5</span><span><b>A mini player instead of a “Now playing” text button.</b> It exists only while a session is active, shows book, speaker and position, offers pause directly, and opens the full Now-playing screen on tap. It feeds off the same <code>getCurrentSession</code> polling — no new route, no new module.</span></li>
+          <li><span class="dnum">6</span><span><b>Every row answers “where was I?”:</b> a progress bar plus time remaining (“4 h 12 min left”). Raw percentages are a server number; time remaining is the user’s question. Shelf rows and browse rows are the same row — identical shape, so the shelf reads as a shortcut into the list, not a different thing.</span></li>
+          <li><span class="dnum">7</span><span><b>Covers come from the server’s cover proxy</b> (contract v1.4.0), loaded under the app’s own auth and never fetched from Audiobookshelf directly. A title-initial placeholder tile fills the same slot while a cover loads or when a book has none — so a coverless book looks finished, not broken. One cover tile serves both shelf and browse rows.</span></li>
+          <li><span class="dnum">8</span><span><b>Search as a round M3 search bar</b> directly under the app bar — searching is this screen’s main job next to resuming. Finished books show a green check instead of a full bar.</span></li>
+          <li><span class="dnum">9</span><span><b>Reload is pull-to-refresh, with retry everywhere a load can fail.</b> Swipe down to reload (standard M3 indicator, not the knot loader — it is a short inline wait). A failed first load shows the error state with a “Try again” button; a failed refresh over an existing list keeps the list and offers retry in a snackbar action — retry is always the first offered action.</span></li>
         </ol>
         <div class="delta">
           <span class="dt">Δ vs. current implementation</span>
           <ul>
+            <li>A “Continue listening” shelf (most-recently-listened first) now sits above an “All books” header; the browse list keeps every book in place, and a failed shelf load shows an inline retry row instead of blanking the top of the screen.</li>
             <li>The text-button row (“Now playing” / “Settings”) is replaced by an M3 top bar with a gear icon plus the mini player.</li>
-            <li>List rows gain cover placeholders, progress bars and time remaining instead of a plain text label.</li>
+            <li>List rows gain cover art (server proxy, with the title-initial placeholder tile), progress bars and time remaining instead of a plain text label.</li>
           </ul>
         </div>
       </div>
@@ -1149,7 +1230,8 @@
         <tr><td><b>Resume position on the Speakers screen</b></td><td>Item data is already available via the route</td><td>Pure display of server state</td></tr>
         <tr><td><b>Speaker name in Now playing</b></td><td>From the server’s <code>Session</code></td><td>Pure display of server state</td></tr>
         <tr><td><b>Knot loading indicator</b></td><td>Generator emits <code>ratatoskr-spinner.svg</code> (SMIL); app redraws it in Compose (<code>Canvas</code> + <code>PathMeasure</code>); honors reduced motion</td><td>No dependency added, no server involvement</td></tr>
-        <tr><td><b>Cover art in lists</b></td><td>Once the contract provides it; initials placeholders until then</td><td>Contract change goes through the server repo (§4)</td></tr>
+        <tr><td><b>Cover art in lists</b></td><td>Shipped: covers load through the server’s proxy (Coil), with the title-initial tile as the loading / no-cover state</td><td>Contract v1.4.0 (<code>coverUrl</code>); resolved in the wrapper, no domain logic on the phone</td></tr>
+        <tr><td><b>Continue-listening shelf</b></td><td>A second library query (<code>GET /library/in-progress</code>) feeding a vertical section above the browse list; membership and order are the server’s</td><td>Additive: the browse-list query is unchanged, and the shelf endpoint goes through the server repo (§4)</td></tr>
         <tr><td colspan="3" style="color:var(--muted); font-size:13px">Unchanged: the six screens and two modules (§13), the tech stack (§12), the TOFU mechanics (§6), and the rule that no domain logic lives on the phone.</td></tr>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- Screen 03 (Library) mockup gains a "Continue listening" shelf (2 rows, most-recently-listened first) above an "All books" header, using the row shape/cover rendering established by #55, plus a second phone depicting the shelf-slot error state (inline tap-to-retry row).
- Decisions column records the settled choices: vertical section (not a carousel), no dedup / no browse-list badge (shelf is a view, not a partition), search hides the shelf, and the slot rule data > error row > nothing. German headers "Weiterhören" / "Alle Bücher" are recorded.
- Reconciles stale cover-placeholder wording with the cover art merged in #55 (contract v1.4.0): covers now load through the server's proxy with the title-initial placeholder tile as the loading/no-cover state, in both the decisions column and the implementation table. Adds a proposed implementation-table row for the shelf (`GET /library/in-progress`) and a delta-list entry.

Closes #82

## Test plan
- [x] Rendered `docs/ux-design.html` in a browser; confirmed both screen-03 phones render at correct size with no horizontal overflow.
- [x] Confirmed shelf/browse rows share the same `.lrow` markup (identical shape) and that Project Hail Mary / The Hobbit appear in both the shelf and "All books" (no-dedup depicted, not just described).
- [x] Confirmed a `.dark` override exists for the new shelf-error panel, matching every other themed atom.
- [x] Ran the repo's two-axis code review (Standards + Spec) against `main`; addressed the two actionable findings (missing dark-mode rule, placeholder-tile wording drift).
- N/A: no app code changed, so no typecheck/test suite applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)