### PR TITLE
feat(library): continue-listening shelf on the Library screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 10400
-        versionName = "1.4.0"
+        versionCode = 10500
+        versionName = "1.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
@@ -25,6 +25,9 @@ class RatatoskrDispatcher(
     private val login: () -> MockResponse = { jsonResponse(WireFixtures.authTokensJson()) },
     private val speakers: String = WireFixtures.speakerListJson(),
     private val libraryPage: String = WireFixtures.libraryPageJson(),
+    // Empty by default: the flows' row counts and "first row" taps predate the shelf, and an
+    // empty shelf renders the screen exactly as before it existed.
+    private val inProgressShelf: String = WireFixtures.inProgressShelfJson(items = emptyList()),
     private val sessionDurationSeconds: Double = 600.0,
     /** Optional embedded `LibraryItemSummary` JSON for the session's `item` member. */
     private val sessionItemJson: String? = null,
@@ -60,6 +63,7 @@ class RatatoskrDispatcher(
             // is not part of the happy path; answer defensively.
             path.startsWith("/v1/library/items/") -> MockResponse().setResponseCode(404)
             path == "/v1/library/items" -> jsonResponse(libraryPage)
+            path == "/v1/library/in-progress" -> jsonResponse(inProgressShelf)
             path == "/v1/sessions/current" && request.method == "PUT" -> {
                 ended = false
                 state = "playing"

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -5,8 +5,8 @@
  */
 package io.github.xexanos.ratatoskr.ui.library
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -55,6 +56,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -79,6 +81,8 @@ import io.github.xexanos.ratatoskr.ui.rememberDelayedVisible
 import io.github.xexanos.ratatoskr.ui.text
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -94,6 +98,10 @@ import kotlin.math.roundToInt
 data class LibraryUiState(
     val loading: Boolean = false,
     val items: List<LibraryItemSummary> = emptyList(),
+    // The continue-listening shelf, most-recently-listened first as the server delivered it.
+    // Empty means "no section" - the UI renders nothing for it. Held (not cleared) across
+    // search reloads, so clearing the search restores the shelf without a refetch.
+    val shelfItems: List<LibraryItemSummary> = emptyList(),
     // Cursor for the page after the ones already in `items`; null once the last page is in.
     val nextCursor: String? = null,
     val loadingMore: Boolean = false,
@@ -128,6 +136,10 @@ class LibraryViewModel(
     // Explicit reload requests (pull-to-refresh, retry-after-error). Buffered so one is kept if
     // it arrives mid-load and coalesced with any others.
     private val refreshRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    // Whether the shelf has ever loaded successfully. Distinguishes the first no-query load
+    // (fetch the shelf) from a search being cleared (redisplay the held shelf, no refetch).
+    private var shelfLoaded = false
 
     init {
         // One reload pipeline for the whole screen. Two sources feed it, both funnelled through
@@ -182,19 +194,44 @@ class LibraryViewModel(
             // list and reports via the snackbar rather than wiping to the full-screen error.
             _uiState.value =
                 if (showAsRefresh) _uiState.value.copy(refreshing = false, refreshError = UiError.NoServer)
-                else LibraryUiState(error = UiError.NoServer)
+                else LibraryUiState(error = UiError.NoServer, shelfItems = _uiState.value.shelfItems)
             return
         }
-        _uiState.value = when (val result = client.listLibraryItems(query = query)) {
-            is ApiResult.Success ->
-                LibraryUiState(items = result.data.items, nextCursor = result.data.nextCursor)
-            is ApiResult.Failure ->
-                if (showAsRefresh) {
-                    // A refresh over an existing list failed: keep the list, report via a snackbar.
-                    _uiState.value.copy(refreshing = false, refreshError = UiError.Domain(result.error))
-                } else {
-                    LibraryUiState(error = UiError.Domain(result.error))
+        // The shelf is never fetched while a query is active: search results get the full
+        // screen, and the held shelf reappears on clear WITHOUT a refetch - which is also why
+        // a query-clear reload (query back to null, shelf already loaded) skips it. With no
+        // query it rides along on the first load and on user-triggered reloads, in parallel
+        // with the page; the single loading state waits for both, so the shelf never pops in
+        // after the list.
+        val fetchShelf = query == null && (userTriggered || !shelfLoaded)
+        coroutineScope {
+            val shelfDeferred = if (fetchShelf) async { client.listInProgressItems() } else null
+            val pageResult = client.listLibraryItems(query = query)
+            val shelfItems = when (val shelfResult = shelfDeferred?.await()) {
+                is ApiResult.Success -> {
+                    shelfLoaded = true
+                    shelfResult.data
                 }
+                // Not fetched, or failed: keep whatever is held - stale beats a blanked shelf.
+                // (The visible, retryable shelf-error row from the spec is a follow-up cut;
+                // this tracer covers the happy path, issue #83.)
+                else -> _uiState.value.shelfItems
+            }
+            _uiState.value = when (pageResult) {
+                is ApiResult.Success ->
+                    LibraryUiState(
+                        items = pageResult.data.items,
+                        nextCursor = pageResult.data.nextCursor,
+                        shelfItems = shelfItems,
+                    )
+                is ApiResult.Failure ->
+                    if (showAsRefresh) {
+                        // A refresh over an existing list failed: keep the list, report via a snackbar.
+                        _uiState.value.copy(refreshing = false, refreshError = UiError.Domain(pageResult.error))
+                    } else {
+                        LibraryUiState(error = UiError.Domain(pageResult.error), shelfItems = shelfItems)
+                    }
+            }
         }
     }
 
@@ -301,9 +338,11 @@ private fun LibraryContent(
     onOpenNowPlaying: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+    // Horizontal padding sits on the top bar and search field, NOT the whole column: the list
+    // below needs the full width so the shelf's tonal band can run edge to edge.
+    Column(modifier = Modifier.fillMaxSize()) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).padding(top = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -341,7 +380,7 @@ private fun LibraryContent(
             },
             singleLine = true,
             shape = MaterialTheme.shapes.large,
-            modifier = Modifier.fillMaxWidth().testTag(UiTestTags.LIBRARY_SEARCH),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag(UiTestTags.LIBRARY_SEARCH),
         )
         when {
             // The delay covers both first load and search: quick responses never flash the
@@ -384,6 +423,10 @@ private fun LibraryContent(
                 LaunchedEffect(nearEnd, state.nextCursor) {
                     if (nearEnd && state.nextCursor != null) onLoadMore()
                 }
+                // The shelf hides the moment the search FIELD is non-blank (not the debounced
+                // query): results get the full screen instantly, and the held shelf comes
+                // straight back when the field is cleared.
+                val shelfVisible = query.isBlank() && state.shelfItems.isNotEmpty()
                 PullToRefreshBox(
                     isRefreshing = state.refreshing,
                     onRefresh = onRefresh,
@@ -392,11 +435,46 @@ private fun LibraryContent(
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(top = 16.dp, bottom = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        // Row spacing is each row's bottom padding (not spacedBy): the shelf's
+                        // band must also fill the gaps between its rows, and item-owned padding
+                        // keeps the band continuous where an arrangement gap would slice it.
+                        contentPadding = PaddingValues(top = if (shelfVisible) 12.dp else 16.dp, bottom = 24.dp),
                     ) {
-                        items(state.items, key = { it.id }) { item ->
-                            LibraryRow(item, onClick = { onOpenItem(item.id) })
+                        if (shelfVisible) {
+                            // Keys are namespaced per section ("shelf:"/"browse:"): shelf books
+                            // also keep their place in the browse list below (no deduplication),
+                            // so a bare item id could occur twice in one LazyColumn.
+                            item(key = "shelf-header") {
+                                LibrarySectionHeader(
+                                    stringResource(R.string.library_shelf_header),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(MaterialTheme.colorScheme.surfaceContainer),
+                                )
+                            }
+                            items(state.shelfItems, key = { "shelf:${it.id}" }) { item ->
+                                Box(
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .background(MaterialTheme.colorScheme.surfaceContainer)
+                                        .padding(horizontal = 16.dp)
+                                        .padding(bottom = 8.dp),
+                                ) {
+                                    LibraryRow(item, onClick = { onOpenItem(item.id) })
+                                }
+                            }
+                            // The hairline that closes the tonal band (screen 03, decision 6).
+                            item(key = "shelf-edge") {
+                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                            }
+                            item(key = "browse-header") {
+                                LibrarySectionHeader(stringResource(R.string.library_all_books_header))
+                            }
+                        }
+                        items(state.items, key = { "browse:${it.id}" }) { item ->
+                            Box(Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp)) {
+                                LibraryRow(item, onClick = { onOpenItem(item.id) })
+                            }
                         }
                         if (state.nextCursor != null) {
                             item(key = "load-more") {
@@ -406,7 +484,7 @@ private fun LibraryContent(
                                             .fillMaxWidth()
                                             .heightIn(min = 48.dp)
                                             .clickable(onClick = onLoadMore)
-                                            .padding(vertical = 12.dp),
+                                            .padding(horizontal = 16.dp, vertical = 12.dp),
                                         contentAlignment = Alignment.Center,
                                     ) {
                                         Text(
@@ -449,6 +527,21 @@ private fun EmptyLibrary(query: String) {
         } else {
             stringResource(R.string.library_no_results_body, query)
         },
+    )
+}
+
+// Marked as a heading so the shelf/browse boundary is navigable non-visually, mirroring what
+// the tonal band does for sighted users.
+@Composable
+private fun LibrarySectionHeader(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.secondary,
+        fontWeight = FontWeight.Medium,
+        modifier = modifier
+            .semantics { heading() }
+            .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 6.dp),
     )
 }
 
@@ -530,7 +623,32 @@ private val previewItems = listOf(
     LibraryItemSummary("3", "Dune", "Frank Herbert", 75_600.0, null, null),
 )
 
-@Preview(name = "Library - loaded", widthDp = 360, heightDp = 800)
+// Most-recently-listened first, as the server would deliver it. "The Hobbit" also sits in
+// previewItems: the shelf is a view onto the library, not a partition, so the same book
+// appearing in both sections is the state to preview.
+private val previewShelfItems = listOf(
+    LibraryItemSummary("4", "A Wizard of Earthsea", "Ursula K. Le Guin", 25_200.0, null, Progress(9_100.0, false)),
+    LibraryItemSummary("1", "The Hobbit", "J. R. R. Tolkien", 39_600.0, null, Progress(12_600.0, false)),
+)
+
+@Preview(name = "Library - shelf loaded", widthDp = 360, heightDp = 800)
+@Composable
+internal fun LibraryShelfLoadedPreview() = RatatoskrTheme {
+    Surface {
+        LibraryContent(
+            state = LibraryUiState(items = previewItems, shelfItems = previewShelfItems),
+            query = "",
+            onQueryChange = {},
+            onOpenItem = {},
+            onOpenNowPlaying = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+// An empty shelf renders no section at all: this must look exactly like the screen before the
+// shelf existed - no headers, no empty band.
+@Preview(name = "Library - loaded, empty shelf", widthDp = 360, heightDp = 800)
 @Composable
 internal fun LibraryLoadedPreview() = RatatoskrTheme {
     Surface {

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -213,8 +213,8 @@ class LibraryViewModel(
                     shelfResult.data
                 }
                 // Not fetched, or failed: keep whatever is held - stale beats a blanked shelf.
-                // (The visible, retryable shelf-error row from the spec is a follow-up cut;
-                // this tracer covers the happy path, issue #83.)
+                // (This tracer covers the happy path, issue #83; the visible, retryable
+                // shelf-error row from the spec is the follow-up cut, issue #84.)
                 else -> _uiState.value.shelfItems
             }
             _uiState.value = when (pageResult) {
@@ -638,6 +638,24 @@ internal fun LibraryShelfLoadedPreview() = RatatoskrTheme {
         LibraryContent(
             state = LibraryUiState(items = previewItems, shelfItems = previewShelfItems),
             query = "",
+            onQueryChange = {},
+            onOpenItem = {},
+            onOpenNowPlaying = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+// A non-blank search field hides the shelf and both headers even though the held shelf items
+// are still in state - the visibility rule lives here in previews (spec #80's testing
+// decision), to be picked up by the screenshot goldens (#76).
+@Preview(name = "Library - searching, shelf hidden", widthDp = 360, heightDp = 800)
+@Composable
+internal fun LibrarySearchingShelfHiddenPreview() = RatatoskrTheme {
+    Surface {
+        LibraryContent(
+            state = LibraryUiState(items = previewItems.take(1), shelfItems = previewShelfItems),
+            query = "hobbit",
             onQueryChange = {},
             onOpenItem = {},
             onOpenNowPlaying = {},

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/theme/Color.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/theme/Color.kt
@@ -25,6 +25,10 @@ val OnBackgroundLight = Color(0xFF211A17)
 val SurfaceVariantLight = Color(0xFFF4DED5)
 val OnSurfaceVariantLight = Color(0xFF53433D)
 val OutlineLight = Color(0xFF85736C)
+// Tonal container band (the search bar's container tone in the design doc, used by the
+// continue-listening shelf) and the hairline edge that closes it.
+val SurfaceContainerLight = Color(0xFFF6EAE2)
+val OutlineVariantLight = Color(0xFFE5D2C4)
 
 // Dark
 val CopperPrimaryDark = Color(0xFFFFB4A3)
@@ -39,3 +43,6 @@ val OnBackgroundDark = Color(0xFFF1DFD9)
 val SurfaceVariantDark = Color(0xFF53433D)
 val OnSurfaceVariantDark = Color(0xFFD8C2B9)
 val OutlineDark = Color(0xFFA08D85)
+// See the light-side note: shelf band and its hairline edge.
+val SurfaceContainerDark = Color(0xFF241914)
+val OutlineVariantDark = Color(0xFF3A2A22)

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/theme/Theme.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/theme/Theme.kt
@@ -34,6 +34,8 @@ private val DarkColorScheme = darkColorScheme(
     surfaceVariant = SurfaceVariantDark,
     onSurfaceVariant = OnSurfaceVariantDark,
     outline = OutlineDark,
+    outlineVariant = OutlineVariantDark,
+    surfaceContainer = SurfaceContainerDark,
 )
 
 private val LightColorScheme = lightColorScheme(
@@ -51,6 +53,8 @@ private val LightColorScheme = lightColorScheme(
     surfaceVariant = SurfaceVariantLight,
     onSurfaceVariant = OnSurfaceVariantLight,
     outline = OutlineLight,
+    outlineVariant = OutlineVariantLight,
+    surfaceContainer = SurfaceContainerLight,
 )
 
 // The app's corner-radius scale - the single source of truth for shapes, so screens use

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,8 @@
     <string name="library_no_results_title">Keine Treffer</string>
     <string name="library_empty_body">Hörbücher von deinem Audiobookshelf-Server erscheinen hier.</string>
     <string name="library_no_results_body">Keine Hörbücher passen zu %1$s. Versuche es mit einer kürzeren Suche.</string>
+    <string name="library_shelf_header">Weiterhören</string>
+    <string name="library_all_books_header">Alle Bücher</string>
     <string name="library_finished">Abgeschlossen</string>
     <string name="library_percent">%1$d&#160;%%</string>
     <string name="library_loading_more">Weitere Hörbücher werden geladen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,8 @@
     <string name="library_no_results_title">No matches</string>
     <string name="library_empty_body">Audiobooks from your Audiobookshelf server will show up here.</string>
     <string name="library_no_results_body">No audiobooks match %1$s. Try a shorter search.</string>
+    <string name="library_shelf_header">Continue listening</string>
+    <string name="library_all_books_header">All books</string>
     <string name="library_finished">Finished</string>
     <string name="library_percent">%1$d%%</string>
     <string name="library_loading_more">Loading more audiobooks</string>

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -57,7 +57,7 @@ class LibraryViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
             jsonResponse(
@@ -86,7 +86,7 @@ class LibraryViewModelTest {
      * dispatches and their request logs stay untouched by the shelf request the initial load
      * now also fires.
      */
-    private fun dispatchItems(
+    private fun dispatchLibrary(
         shelf: () -> MockResponse = ::defaultShelfResponse,
         items: (okhttp3.mockwebserver.RecordedRequest) -> MockResponse,
     ) {
@@ -176,7 +176,7 @@ class LibraryViewModelTest {
     @Test
     fun `loadMore follows the cursor and appends the next page`() = runTest(dispatcher) {
         val receivedCursors = Collections.synchronizedList(mutableListOf<String?>())
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             receivedCursors += cursor
             val body = if (cursor == null) {
@@ -211,7 +211,7 @@ class LibraryViewModelTest {
     @Test
     fun `a failing next page keeps the list and flags a retryable error`() = runTest(dispatcher) {
         var failNextPage = true
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             if (cursor != null && failNextPage) {
                 MockResponse().setResponseCode(502)
@@ -249,7 +249,7 @@ class LibraryViewModelTest {
 
     @Test
     fun `a new query restarts pagination from the first page`() = runTest(dispatcher) {
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             val q = request.requestUrl?.queryParameter("q")
             jsonResponse(
@@ -282,7 +282,7 @@ class LibraryViewModelTest {
         // structure protects against (unlike the test above, which changes query only after the
         // page has fully landed).
         val pageBlocked = CountDownLatch(1)
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
@@ -343,7 +343,7 @@ class LibraryViewModelTest {
     @Test
     fun `retry after a failed load re-issues the load and clears the error`() = runTest(dispatcher) {
         val failFirst = AtomicBoolean(true)
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
             if (failFirst.getAndSet(false)) {
@@ -366,7 +366,7 @@ class LibraryViewModelTest {
     @Test
     fun `a failed refresh keeps the list and surfaces a one-shot refreshError`() = runTest(dispatcher) {
         val failNow = AtomicBoolean(false)
-        dispatchItems { request ->
+        dispatchLibrary { request ->
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
             if (failNow.get()) {
@@ -433,7 +433,7 @@ class LibraryViewModelTest {
         // neither response is out proves the fetches run in parallel (a sequential load would
         // block the second request behind the first's held response).
         val responsesBlocked = CountDownLatch(1)
-        dispatchItems(
+        dispatchLibrary(
             shelf = {
                 responsesBlocked.await()
                 defaultShelfResponse()
@@ -464,7 +464,7 @@ class LibraryViewModelTest {
 
     @Test
     fun `a successfully empty shelf loads as no shelf items`() = runTest(dispatcher) {
-        dispatchItems(shelf = { jsonResponse(WireFixtures.inProgressShelfJson(items = emptyList())) }) { request ->
+        dispatchLibrary(shelf = { jsonResponse(WireFixtures.inProgressShelfJson(items = emptyList())) }) { request ->
             receivedQueries += request.requestUrl?.queryParameter("q")
             jsonResponse(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = "all"))))
         }
@@ -501,7 +501,7 @@ class LibraryViewModelTest {
 
     @Test
     fun `a failing request surfaces the mapped error`() = runTest(dispatcher) {
-        dispatchItems {
+        dispatchLibrary {
             MockResponse().setResponseCode(502)
                 .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
         }

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -49,21 +49,56 @@ class LibraryViewModelTest {
 
     private val receivedQueries = Collections.synchronizedList(mutableListOf<String?>())
 
+    // The `limit` query parameter of every in-progress shelf request, in arrival order. Doubles
+    // as the shelf request log: its size counts shelf fetches, its values must all be null (the
+    // server owns the shelf size; the app never sends a limit).
+    private val receivedShelfLimits = Collections.synchronizedList(mutableListOf<String?>())
+
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        server.dispatch { request ->
+        dispatchItems { request ->
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
-            MockResponse().setResponseCode(200)
-                .setHeader("Content-Type", "application/json")
-                .setBody(
-                    WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))),
-                )
+            jsonResponse(
+                WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))),
+            )
         }
     }
 
     @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun jsonResponse(body: String): MockResponse =
+        MockResponse().setResponseCode(200)
+            .setHeader("Content-Type", "application/json")
+            .setBody(body)
+
+    private fun defaultShelfResponse(): MockResponse =
+        jsonResponse(
+            WireFixtures.inProgressShelfJson(
+                items = listOf(WireFixtures.libraryItemSummaryJson(id = "s1", title = "shelf book")),
+            ),
+        )
+
+    /**
+     * Routes the two library endpoints in one place: shelf requests are logged (their `limit`
+     * param) and answered by [shelf], everything else goes to [items] - so the per-test items
+     * dispatches and their request logs stay untouched by the shelf request the initial load
+     * now also fires.
+     */
+    private fun dispatchItems(
+        shelf: () -> MockResponse = ::defaultShelfResponse,
+        items: (okhttp3.mockwebserver.RecordedRequest) -> MockResponse,
+    ) {
+        server.dispatch { request ->
+            if (request.requestUrl?.encodedPath?.endsWith("/library/in-progress") == true) {
+                receivedShelfLimits += request.requestUrl?.queryParameter("limit")
+                shelf()
+            } else {
+                items(request)
+            }
+        }
+    }
 
     private fun trustedConnectionManager(): ConnectionManager {
         val file = tempFolder.root.resolve("connection_${System.nanoTime()}.preferences_pb")
@@ -141,7 +176,7 @@ class LibraryViewModelTest {
     @Test
     fun `loadMore follows the cursor and appends the next page`() = runTest(dispatcher) {
         val receivedCursors = Collections.synchronizedList(mutableListOf<String?>())
-        server.dispatch { request ->
+        dispatchItems { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             receivedCursors += cursor
             val body = if (cursor == null) {
@@ -154,9 +189,7 @@ class LibraryViewModelTest {
                     items = listOf(WireFixtures.libraryItemSummaryJson(id = "i2", title = "page two")),
                 )
             }
-            MockResponse().setResponseCode(200)
-                .setHeader("Content-Type", "application/json")
-                .setBody(body)
+            jsonResponse(body)
         }
         val viewModel = LibraryViewModel(trustedConnectionManager())
         settleState { viewModel.uiState.value.items.isNotEmpty() }
@@ -178,22 +211,20 @@ class LibraryViewModelTest {
     @Test
     fun `a failing next page keeps the list and flags a retryable error`() = runTest(dispatcher) {
         var failNextPage = true
-        server.dispatch { request ->
+        dispatchItems { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             if (cursor != null && failNextPage) {
                 MockResponse().setResponseCode(502)
                     .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
             } else {
-                MockResponse().setResponseCode(200)
-                    .setHeader("Content-Type", "application/json")
-                    .setBody(
-                        WireFixtures.libraryPageJson(
-                            items = listOf(
-                                WireFixtures.libraryItemSummaryJson(id = "i-$cursor", title = "page after $cursor"),
-                            ),
-                            nextCursor = if (cursor == null) "c2" else null,
+                jsonResponse(
+                    WireFixtures.libraryPageJson(
+                        items = listOf(
+                            WireFixtures.libraryItemSummaryJson(id = "i-$cursor", title = "page after $cursor"),
                         ),
-                    )
+                        nextCursor = if (cursor == null) "c2" else null,
+                    ),
+                )
             }
         }
         val viewModel = LibraryViewModel(trustedConnectionManager())
@@ -218,21 +249,19 @@ class LibraryViewModelTest {
 
     @Test
     fun `a new query restarts pagination from the first page`() = runTest(dispatcher) {
-        server.dispatch { request ->
+        dispatchItems { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             val q = request.requestUrl?.queryParameter("q")
-            MockResponse().setResponseCode(200)
-                .setHeader("Content-Type", "application/json")
-                .setBody(
-                    WireFixtures.libraryPageJson(
-                        items = listOf(
-                            WireFixtures.libraryItemSummaryJson(id = "$q-$cursor", title = q ?: "all"),
-                        ),
-                        // Every page claims a successor, so the cursor is non-null when the
-                        // query changes - the fresh load must not carry it over.
-                        nextCursor = "next-after-$cursor",
+            jsonResponse(
+                WireFixtures.libraryPageJson(
+                    items = listOf(
+                        WireFixtures.libraryItemSummaryJson(id = "$q-$cursor", title = q ?: "all"),
                     ),
-                )
+                    // Every page claims a successor, so the cursor is non-null when the
+                    // query changes - the fresh load must not carry it over.
+                    nextCursor = "next-after-$cursor",
+                ),
+            )
         }
         val viewModel = LibraryViewModel(trustedConnectionManager())
         settleState { viewModel.uiState.value.items.isNotEmpty() }
@@ -253,29 +282,25 @@ class LibraryViewModelTest {
         // structure protects against (unlike the test above, which changes query only after the
         // page has fully landed).
         val pageBlocked = CountDownLatch(1)
-        server.dispatch { request ->
+        dispatchItems { request ->
             val cursor = request.requestUrl?.queryParameter("cursor")
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
             when {
                 cursor != null -> {
                     pageBlocked.await()
-                    MockResponse().setResponseCode(200)
-                        .setHeader("Content-Type", "application/json")
-                        .setBody(
-                            WireFixtures.libraryPageJson(
-                                items = listOf(WireFixtures.libraryItemSummaryJson(id = "stale", title = "stale page")),
-                            ),
-                        )
-                }
-                else -> MockResponse().setResponseCode(200)
-                    .setHeader("Content-Type", "application/json")
-                    .setBody(
+                    jsonResponse(
                         WireFixtures.libraryPageJson(
-                            items = listOf(WireFixtures.libraryItemSummaryJson(id = "${q}-first", title = q ?: "all")),
-                            nextCursor = if (q == null) "c2" else null,
+                            items = listOf(WireFixtures.libraryItemSummaryJson(id = "stale", title = "stale page")),
                         ),
                     )
+                }
+                else -> jsonResponse(
+                    WireFixtures.libraryPageJson(
+                        items = listOf(WireFixtures.libraryItemSummaryJson(id = "${q}-first", title = q ?: "all")),
+                        nextCursor = if (q == null) "c2" else null,
+                    ),
+                )
             }
         }
         val viewModel = LibraryViewModel(trustedConnectionManager())
@@ -318,16 +343,14 @@ class LibraryViewModelTest {
     @Test
     fun `retry after a failed load re-issues the load and clears the error`() = runTest(dispatcher) {
         val failFirst = AtomicBoolean(true)
-        server.dispatch { request ->
+        dispatchItems { request ->
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
             if (failFirst.getAndSet(false)) {
                 MockResponse().setResponseCode(502)
                     .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
             } else {
-                MockResponse().setResponseCode(200)
-                    .setHeader("Content-Type", "application/json")
-                    .setBody(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))))
+                jsonResponse(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))))
             }
         }
         val viewModel = LibraryViewModel(trustedConnectionManager())
@@ -343,16 +366,14 @@ class LibraryViewModelTest {
     @Test
     fun `a failed refresh keeps the list and surfaces a one-shot refreshError`() = runTest(dispatcher) {
         val failNow = AtomicBoolean(false)
-        server.dispatch { request ->
+        dispatchItems { request ->
             val q = request.requestUrl?.queryParameter("q")
             receivedQueries += q
             if (failNow.get()) {
                 MockResponse().setResponseCode(502)
                     .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
             } else {
-                MockResponse().setResponseCode(200)
-                    .setHeader("Content-Type", "application/json")
-                    .setBody(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))))
+                jsonResponse(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = q ?: "all"))))
             }
         }
         val viewModel = LibraryViewModel(trustedConnectionManager())
@@ -407,8 +428,80 @@ class LibraryViewModelTest {
     }
 
     @Test
+    fun `first load fetches shelf and page in parallel and lands as one loaded state`() = runTest(dispatcher) {
+        // Both responses are held until the test releases them. Both requests arriving while
+        // neither response is out proves the fetches run in parallel (a sequential load would
+        // block the second request behind the first's held response).
+        val responsesBlocked = CountDownLatch(1)
+        dispatchItems(
+            shelf = {
+                responsesBlocked.await()
+                defaultShelfResponse()
+            },
+        ) { request ->
+            receivedQueries += request.requestUrl?.queryParameter("q")
+            responsesBlocked.await()
+            jsonResponse(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = "all"))))
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+
+        settleState { receivedQueries.size == 1 && receivedShelfLimits.size == 1 }
+
+        // Neither response has landed: still the single full-screen loading state, and the
+        // shelf request named no limit - the server owns the shelf size.
+        assertTrue(viewModel.uiState.value.loading)
+        assertTrue(viewModel.uiState.value.items.isEmpty())
+        assertEquals(listOf(null), receivedShelfLimits)
+
+        responsesBlocked.countDown()
+        settleState { !viewModel.uiState.value.loading }
+
+        // One loaded state carries both sections - no shelf popping in after the list.
+        assertEquals(listOf("all"), viewModel.uiState.value.items.map { it.title })
+        assertEquals(listOf("shelf book"), viewModel.uiState.value.shelfItems.map { it.title })
+        assertEquals(null, viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `a successfully empty shelf loads as no shelf items`() = runTest(dispatcher) {
+        dispatchItems(shelf = { jsonResponse(WireFixtures.inProgressShelfJson(items = emptyList())) }) { request ->
+            receivedQueries += request.requestUrl?.queryParameter("q")
+            jsonResponse(WireFixtures.libraryPageJson(items = listOf(WireFixtures.libraryItemSummaryJson(title = "all"))))
+        }
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+
+        settleState { viewModel.uiState.value.items.isNotEmpty() }
+
+        // "Successfully empty" is a loaded state with nothing on the shelf (the UI renders no
+        // section for it), not an error.
+        assertTrue(viewModel.uiState.value.shelfItems.isEmpty())
+        assertEquals(null, viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `searching never refetches the shelf and clearing the search restores it from held state`() = runTest(dispatcher) {
+        val viewModel = LibraryViewModel(trustedConnectionManager())
+        settleState { viewModel.uiState.value.shelfItems.isNotEmpty() }
+
+        viewModel.search("cat")
+        settleState { viewModel.uiState.value.items.singleOrNull()?.title == "cat" }
+
+        // The search reload asked only for results; the shelf stays held in state (the search
+        // field hides it UI-side) so clearing can bring it back instantly.
+        assertEquals(1, receivedShelfLimits.size)
+        assertEquals(listOf("shelf book"), viewModel.uiState.value.shelfItems.map { it.title })
+
+        viewModel.search("")
+        settleState { receivedQueries.size == 3 && !viewModel.uiState.value.loading }
+
+        // Clearing reloaded the browse list but the shelf came from held state - no refetch.
+        assertEquals(1, receivedShelfLimits.size)
+        assertEquals(listOf("shelf book"), viewModel.uiState.value.shelfItems.map { it.title })
+    }
+
+    @Test
     fun `a failing request surfaces the mapped error`() = runTest(dispatcher) {
-        server.dispatch {
+        dispatchItems {
             MockResponse().setResponseCode(502)
                 .setBody("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""")
         }

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/Mappers.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/Mappers.kt
@@ -16,6 +16,7 @@ import io.github.xexanos.ratatoskr.network.domain.Session
 import io.github.xexanos.ratatoskr.network.domain.Speaker
 import io.github.xexanos.ratatoskr.network.generated.model.AuthTokens as GenAuthTokens
 import io.github.xexanos.ratatoskr.network.generated.model.LibraryItem as GenLibraryItem
+import io.github.xexanos.ratatoskr.network.generated.model.LibraryItemList as GenLibraryItemList
 import io.github.xexanos.ratatoskr.network.generated.model.LibraryItemPage as GenLibraryItemPage
 import io.github.xexanos.ratatoskr.network.generated.model.LibraryItemSummary as GenLibraryItemSummary
 import io.github.xexanos.ratatoskr.network.generated.model.PlaybackState as GenPlaybackState
@@ -85,6 +86,13 @@ internal fun GenLibraryItem.toDomain(baseUrl: String): LibraryItem =
 
 internal fun GenLibraryItemPage.toDomain(baseUrl: String): LibraryPage =
     LibraryPage(items = items.map { it.toDomain(baseUrl) }, nextCursor = nextCursor)
+
+/**
+ * The in-progress shelf is a complete, bounded set, not a page - the envelope carries no
+ * cursor, so it unwraps to a plain list of the existing summary model (no new domain type).
+ */
+internal fun GenLibraryItemList.toDomain(baseUrl: String): List<LibraryItemSummary> =
+    items.map { it.toDomain(baseUrl) }
 
 internal fun GenPlaybackState.toDomain(): PlaybackState = when (this) {
     GenPlaybackState.playing -> PlaybackState.PLAYING

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -9,6 +9,7 @@ import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.map
 import io.github.xexanos.ratatoskr.network.domain.AuthSession
 import io.github.xexanos.ratatoskr.network.domain.LibraryItem
+import io.github.xexanos.ratatoskr.network.domain.LibraryItemSummary
 import io.github.xexanos.ratatoskr.network.domain.LibraryPage
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
 import io.github.xexanos.ratatoskr.network.domain.Session
@@ -85,6 +86,15 @@ class RatatoskrClient internal constructor(
         cursor: String? = null,
     ): ApiResult<LibraryPage> =
         execute { libraryApi.listLibraryItems(query, limit, cursor) }.map { it.toDomain(baseUrl) }
+
+    /**
+     * The continue-listening shelf: in-progress books, most-recently-listened first. Membership
+     * and order are the server's; the shelf size is its default too - `limit` is deliberately
+     * not sent (the generated default of 25 would silently pin the server's choice, so it is
+     * overridden with null here).
+     */
+    suspend fun listInProgressItems(): ApiResult<List<LibraryItemSummary>> =
+        execute { libraryApi.listInProgressItems(limit = null) }.map { it.toDomain(baseUrl) }
 
     suspend fun getLibraryItem(itemId: String): ApiResult<LibraryItem> =
         execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain(baseUrl) }

--- a/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
+++ b/core-network/src/testFixtures/java/io/github/xexanos/ratatoskr/network/WireFixtures.kt
@@ -86,6 +86,11 @@ object WireFixtures {
         return """{"items":[${items.joinToString(",")}]$c}"""
     }
 
+    /** A `GET /v1/library/in-progress` response body (a `LibraryItemList` - no cursor). */
+    fun inProgressShelfJson(
+        items: List<String> = listOf(libraryItemSummaryJson()),
+    ): String = """{"items":[${items.joinToString(",")}]}"""
+
     /** Minimal JSON string escaping for interpolated values: backslash and double-quote. */
     private fun esc(value: String): String =
         value.replace("\\", "\\\\").replace("\"", "\\\"")

--- a/fastlane/metadata/android/de-DE/changelogs/10500.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10500.txt
@@ -1,0 +1,1 @@
+Die Bibliothek beginnt jetzt mit einem „Weiterhören“-Regal: deine angefangenen Bücher, zuletzt gehört zuerst, ganz oben. Beim Tippen einer Suche verschwindet das Regal; nach dem Leeren ist es sofort wieder da.

--- a/fastlane/metadata/android/en-US/changelogs/10500.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10500.txt
@@ -1,0 +1,1 @@
+The Library now opens with a "Continue listening" shelf: your in-progress books, most recently listened first, right at the top. Typing a search hides the shelf; clearing it brings the shelf straight back.


### PR DESCRIPTION
## Summary

Tracer bullet for the continue-listening shelf (closes #83; spec #80): a vertical section of in-progress books, most-recently-listened first, above the unchanged alphabetical browse list — the happy path end to end through every layer.

- **core-network**: `RatatoskrClient.listInProgressItems()` unwraps the `LibraryItemList` envelope to a plain list of the existing summary model via the mapper seam; `limit` is deliberately never sent (the generated default of 25 is overridden with null), so the server owns the shelf size. New `inProgressShelfJson` wire fixture.
- **ViewModel**: `LibraryUiState.shelfItems`; the initial (and user-triggered) no-query load fetches shelf and first page in parallel behind the single existing full-screen loading state. The shelf is never fetched while a query is active; clearing a search redisplays the held shelf without a refetch. A failed shelf keeps held data — the visible, retryable error row is the follow-up cut (#84).
- **UI**: both sections in the one LazyColumn with per-section namespaced keys (`shelf:`/`browse:`, no deduplication); the shelf sits on a full-bleed tonal surface band (new `surfaceContainer`/`outlineVariant` theme tokens from the design doc) closed by a hairline bottom edge, per the screen 03 UX section, decision 6. Shelf rows reuse `LibraryRow` and navigate identically to browse rows. Headers in EN and DE, marked as accessibility headings. Previews for shelf-loaded, shelf-empty, and searching-hides-shelf (the visibility rule is preview-carried per spec #80, for the screenshot goldens #76).
- **Version**: 1.5.0 bump with en-US and de-DE changelogs (feat ⇒ minor per the release guard).

## Tests

At the established ViewModel-to-wire seam (real ViewModel, real wrapper, generated client against the HTTPS mock server):

- Parallel first load lands as one loaded state — both responses latched until both requests arrived, proving neither fetch queues behind the other — and the shelf request names no `limit`.
- Successfully empty shelf loads as no shelf items (the UI renders no section).
- Searching never refetches the shelf; clearing the search restores it from held state without a refetch.
- All existing browse-list tests stay green; the instrumented `RatatoskrDispatcher` serves the new endpoint (empty shelf by default, so existing flow tests are unchanged).

`lintDebug testDebugUnitTest` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)