### PR TITLE
fix(ui): reconcile the shape scale with the design's radius table

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         targetSdk = 36
         // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH, derived from versionName;
         // releases are v<versionName> git tags (SPEC section 8).
-        versionCode = 10500
-        versionName = "1.5.0"
+        versionCode = 10501
+        versionName = "1.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // R8 rules for the instrumented-test APK. Only take effect when the androidTest APK is

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/auth/SignInScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/auth/SignInScreen.kt
@@ -157,7 +157,8 @@ private fun SignInContent(
             },
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-            shape = MaterialTheme.shapes.large,
+            // 8 dp - the design's text-field radius (ux-design: Shape tokens).
+            shape = MaterialTheme.shapes.small,
             modifier = Modifier.fillMaxWidth(),
         )
         Spacer(Modifier.height(16.dp))
@@ -178,7 +179,7 @@ private fun SignInContent(
                 keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Done,
             ),
-            shape = MaterialTheme.shapes.large,
+            shape = MaterialTheme.shapes.small,
             modifier = Modifier.fillMaxWidth(),
         )
         Spacer(Modifier.height(24.dp))

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/connect/ConnectScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/connect/ConnectScreen.kt
@@ -189,7 +189,8 @@ private fun ConnectContent(
                 null
             },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Go),
-            shape = MaterialTheme.shapes.large,
+            // 8 dp - the design's text-field radius (ux-design: Shape tokens).
+            shape = MaterialTheme.shapes.small,
             modifier = Modifier.fillMaxWidth().testTag(UiTestTags.CONNECT_SERVER_URL),
         )
         Spacer(Modifier.height(16.dp))
@@ -249,7 +250,7 @@ private fun CertificateCard(
     onCancel: () -> Unit,
 ) {
     Surface(
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 2.dp,
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/library/LibraryScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.PlayArrow
@@ -379,7 +380,8 @@ private fun LibraryContent(
                 )
             },
             singleLine = true,
-            shape = MaterialTheme.shapes.large,
+            // Full pill - the design's search-field shape (ux-design: Shape tokens).
+            shape = CircleShape,
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag(UiTestTags.LIBRARY_SEARCH),
         )
         when {
@@ -548,7 +550,7 @@ private fun LibrarySectionHeader(text: String, modifier: Modifier = Modifier) {
 @Composable
 private fun LibraryRow(item: LibraryItemSummary, onClick: () -> Unit) {
     Surface(
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
         modifier = Modifier.fillMaxWidth().testTag(UiTestTags.LIBRARY_ROW).clickable(onClick = onClick),

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
@@ -160,7 +160,7 @@ private fun SettingsContent(
 
         SectionLabel(stringResource(R.string.settings_section_server))
         Surface(
-            shape = MaterialTheme.shapes.extraLarge,
+            shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 1.dp,
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/speakers/SpeakersScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/speakers/SpeakersScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material.icons.filled.SpeakerGroup
@@ -175,7 +174,7 @@ private fun SpeakersContent(
 @Composable
 private fun SpeakerRow(speaker: Speaker, onClick: () -> Unit) {
     Surface(
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
         modifier = Modifier.fillMaxWidth().testTag(UiTestTags.SPEAKER_ROW).clickable(onClick = onClick),
@@ -186,7 +185,9 @@ private fun SpeakerRow(speaker: Speaker, onClick: () -> Unit) {
         ) {
             Surface(
                 modifier = Modifier.size(48.dp),
-                shape = CircleShape,
+                // 16 dp rounded square, not a circle: content tile, same shape family as the
+                // library rows' covers - circles are reserved for controls (ux-design: Shape tokens).
+                shape = MaterialTheme.shapes.large,
                 color = if (speaker.isGroup) {
                     MaterialTheme.colorScheme.secondaryContainer
                 } else {

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/theme/Theme.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/theme/Theme.kt
@@ -7,9 +7,7 @@ package io.github.xexanos.ratatoskr.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -17,7 +15,6 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 
 private val DarkColorScheme = darkColorScheme(
     primary = CopperPrimaryDark,
@@ -57,16 +54,6 @@ private val LightColorScheme = lightColorScheme(
     surfaceContainer = SurfaceContainerLight,
 )
 
-// The app's corner-radius scale - the single source of truth for shapes, so screens use
-// MaterialTheme.shapes.* rather than literal RoundedCornerShape(n.dp). Values match the radii
-// the screens were built with (12 / 16 / 20 dp).
-private val AppShapes = Shapes(
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(12.dp),
-    large = RoundedCornerShape(16.dp),
-    extraLarge = RoundedCornerShape(20.dp),
-)
-
 @Composable
 fun RatatoskrTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
@@ -86,9 +73,11 @@ fun RatatoskrTheme(
     }
 
     CompositionLocalProvider(LocalReducedMotion provides rememberReducedMotion()) {
+        // Deliberately no custom Shapes: the M3 default scale (8 / 12 / 16 / 28 dp) is the
+        // app's corner-radius scale. Which surface uses which token is defined by the shape
+        // table in docs/ux-design.html.
         MaterialTheme(
             colorScheme = colorScheme,
-            shapes = AppShapes,
             typography = Typography,
             content = content,
         )

--- a/docs/ux-design.html
+++ b/docs/ux-design.html
@@ -568,13 +568,14 @@
     </div>
 
     <p class="token-sub">Shape</p>
+    <p style="max-width:640px; color:#4A3C33; margin:0 0 16px;">The radii are Material&nbsp;3’s default shape scale — the theme defines <b>no overrides</b>, so the token column below is what code references. The dp values are listed for review convenience only. <code>medium</code> (12&thinsp;dp) is currently unassigned.</p>
     <div class="table-scroll">
       <table class="tokens">
-        <tr><th>Radius</th><th>Used for</th></tr>
-        <tr><td><code>8 dp</code></td><td>Text fields, cover thumbnails</td></tr>
-        <tr><td><code>16 dp</code></td><td>Cards (certificate, mini player), speaker icons</td></tr>
-        <tr><td><code>24–28 dp</code></td><td>Now-playing cover, dialogs</td></tr>
-        <tr><td><code>full</code></td><td>Buttons, search field, chips — the app’s friendly base shape</td></tr>
+        <tr><th>Token</th><th>Radius</th><th>Used for</th></tr>
+        <tr><td><code>small</code></td><td><code>8 dp</code></td><td>Text fields, cover thumbnails</td></tr>
+        <tr><td><code>large</code></td><td><code>16 dp</code></td><td>Cards (certificate, mini player, settings), list rows (library, speakers), speaker icons</td></tr>
+        <tr><td><code>extraLarge</code></td><td><code>28 dp</code></td><td>Now-playing cover, dialogs</td></tr>
+        <tr><td><code>full</code></td><td>pill</td><td>Buttons, search field, chips — the app’s friendly base shape</td></tr>
       </table>
     </div>
 

--- a/docs/ux-design.html
+++ b/docs/ux-design.html
@@ -568,7 +568,7 @@
     </div>
 
     <p class="token-sub">Shape</p>
-    <p style="max-width:640px; color:#4A3C33; margin:0 0 16px;">The radii are Material&nbsp;3’s default shape scale — the theme defines <b>no overrides</b>, so the token column below is what code references. The dp values are listed for review convenience only. <code>medium</code> (12&thinsp;dp) is currently unassigned.</p>
+    <p style="max-width:640px; color:#4A3C33; margin:0 0 16px;">The radii are Material&nbsp;3’s default shape scale — the theme defines <b>no overrides</b>, so the token column below is what code references. The dp values are listed for review convenience only. <code>medium</code> (12&thinsp;dp) has no assigned surface in this table, and a few surfaces still await a radius decision (error banners, the certificate fingerprint block, the settings server icon) — tracked in issue #89.</p>
     <div class="table-scroll">
       <table class="tokens">
         <tr><th>Token</th><th>Radius</th><th>Used for</th></tr>

--- a/fastlane/metadata/android/de-DE/changelogs/10501.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/10501.txt
@@ -1,0 +1,1 @@
+Optischer Feinschliff: Die Eckenradien folgen jetzt überall dem Design. Das Cover im Wiedergabe-Bildschirm ist weicher gerundet, Karten, Listenzeilen und Lautsprecher-Symbole teilen sich eine einheitliche Form, Textfelder sind straffer, und das Suchfeld der Bibliothek ist eine durchgehende Pille.

--- a/fastlane/metadata/android/en-US/changelogs/10501.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10501.txt
@@ -1,0 +1,1 @@
+Visual polish: corner radii now follow the design everywhere. The Now Playing cover is softer and rounder, cards, list rows and speaker icons share one consistent shape, text fields sit tighter, and the library search field is a full pill.


### PR DESCRIPTION
Closes #85.

The theme's custom `Shapes` block (`extraLarge` = 20dp) was fitted to the radii the screens happened to be built with, not to the design doc — so every `extraLarge` surface drifted: the now-playing cover rendered too tight (20 vs the design's 24–28) and the cards/rows too loose (20 vs 16).

**The decision** (interview with @Xexanos): drop the custom `Shapes` block entirely. M3's default scale (8/12/16/28) *is* the design's scale, future M3 components (dialogs) inherit the right shape for free, and the design table — not the theme — is where surface-to-token assignments live.

**Call-site remaps** to the tokens the design table answers:

- now-playing cover: stays `extraLarge`, now renders 28dp
- certificate card, settings server card, library rows, speaker rows: `extraLarge` → `large` (16dp)
- speaker icon tile: circle → `large` rounded square (a content tile in the same shape family as the covers; circles are reserved for controls)
- sign-in and connect text fields: `large` → `small` (8dp)
- library search field: `large` → full pill

**Design doc**: the shape table gains a Token column so doc and code speak the same language, pins the former "24–28dp" range to 28dp, names list rows in the 16dp row, and states the values are M3 defaults with no overrides.

Surfaces the table has no row for yet (error banners, certificate fingerprint block, settings server icon) are deliberately untouched and tracked in #89. Golden tests (#76), once they land, will pin this corrected state.

Verified: `:app:testDebugUnitTest` and `:app:lintDebug` green; two-axis review (standards + spec) run, its one finding (the table note overclaiming `medium` as unassigned) fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)