### PR TITLE
refactor: concentrate cover-URL knowledge in a CoverEndpoint module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,6 +39,14 @@ In the app's domain model: the absolute, bearer-authenticated URL a cover is loa
 On the wire the server sends an origin-relative path; resolving it is the wrapper's job, so
 nothing above the wrapper ever sees a relative value.
 
+**Cover endpoint** (`CoverEndpoint`):
+The wrapper's single owner of cover-URL knowledge: it resolves the origin-relative `coverUrl`
+to an absolute one (bound once to the server origin) and recognises a URL that points at the
+cover proxy (the shape the `?h=` height parameter applies to). Recognition is host- and
+version-agnostic, so the app's cover-image interceptor consumes it without learning the origin.
+The path shape is mirrored from the contract's `GET /library/items/{id}/cover`; a drift-guard
+test keeps them in step.
+
 **Cover bucket**:
 One of the quantized heights {128, 256, 512, 1024} the app requests covers at (`?h=`),
 rounded up from the rendered size and capped at 1024. Surfaces whose rows land in the same

--- a/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptor.kt
@@ -8,6 +8,7 @@ package io.github.xexanos.ratatoskr.covers
 import coil3.intercept.Interceptor
 import coil3.request.ImageResult
 import coil3.size.Dimension
+import io.github.xexanos.ratatoskr.network.api.CoverEndpoint
 
 /**
  * Appends the bucketed `?h=` parameter to cover requests from the size Coil resolved out of
@@ -24,25 +25,12 @@ internal class CoverHeightInterceptor : Interceptor {
     override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
         val data = chain.request.data
         val height = chain.size.height
-        if (data !is String || !isCoverUrl(data) || height !is Dimension.Pixels) {
+        if (data !is String || !CoverEndpoint.matches(data) || height !is Dimension.Pixels) {
             return chain.proceed()
         }
         val request = chain.request.newBuilder()
             .data(appendCoverHeightParam(data, height.px))
             .build()
         return chain.withRequest(request).proceed()
-    }
-
-    /**
-     * Only the cover proxy understands `h`; leave any other image URL alone. A heuristic on
-     * the proxy's path shape - deliberately host-agnostic, because knowing the server origin
-     * is the wrapper's concern, not this interceptor's. If the server ever returns to sending
-     * absolute URLs (the wrapper's tolerant-reader case), its own covers keep matching; a
-     * foreign URL that happens to share the exact path shape would get one extra query
-     * parameter, which servers ignore.
-     */
-    private fun isCoverUrl(url: String): Boolean {
-        val path = url.substringBefore('?')
-        return path.endsWith("/cover") && path.contains("/library/items/")
     }
 }

--- a/app/src/test/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptorTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/covers/CoverHeightInterceptorTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.covers
+
+import coil3.ColorImage
+import coil3.intercept.Interceptor
+import coil3.request.ErrorResult
+import coil3.request.ImageRequest
+import coil3.request.ImageResult
+import coil3.size.Dimension
+import coil3.size.Size
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * The interceptor's wiring: it must call [CoverEndpoint.matches] on the request's URL and, only
+ * for a cover, append the bucketed `?h=` for the height Coil resolved. The bucket arithmetic
+ * itself is covered by [CoverHeightBucketsTest]; this pins that it is applied to the right URL
+ * at the right size - the seam the pure helpers cannot reach on their own.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class CoverHeightInterceptorTest {
+
+    private val context = RuntimeEnvironment.getApplication()
+    private val interceptor = CoverHeightInterceptor()
+
+    private fun dataReaching(url: String, heightPx: Int): Any? {
+        var proceededData: Any? = null
+        val chain = RecordingChain(
+            request = ImageRequest.Builder(context).data(url).build(),
+            size = Size(Dimension.Undefined, Dimension.Pixels(heightPx)),
+        ) { proceededData = it.data }
+        runBlocking { interceptor.intercept(chain) }
+        return proceededData
+    }
+
+    @Test
+    fun `appends the bucketed h to a cover url`() {
+        assertEquals(
+            "https://srv/v1/library/items/42/cover?h=256",
+            dataReaching("https://srv/v1/library/items/42/cover", 168),
+        )
+    }
+
+    @Test
+    fun `leaves a non-cover url untouched`() {
+        assertEquals(
+            "https://srv/img/banner.png",
+            dataReaching("https://srv/img/banner.png", 168),
+        )
+    }
+
+    private class RecordingChain(
+        override val request: ImageRequest,
+        override val size: Size,
+        private val onProceed: (ImageRequest) -> Unit,
+    ) : Interceptor.Chain {
+        override fun withRequest(request: ImageRequest): Interceptor.Chain =
+            RecordingChain(request, size, onProceed)
+
+        override fun withSize(size: Size): Interceptor.Chain =
+            RecordingChain(request, size, onProceed)
+
+        override suspend fun proceed(): ImageResult {
+            onProceed(request)
+            return ErrorResult(ColorImage(), request, RuntimeException("stub"))
+        }
+    }
+}

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/CoverEndpoint.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/CoverEndpoint.kt
@@ -1,0 +1,49 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.api
+
+/**
+ * The single owner of what the app knows about the server's cover endpoint: how to reach it
+ * ([resolve]) and how to recognise a URL that points at it ([matches]). Bound once to a server
+ * origin, so nothing above the wrapper re-derives the cover path or the origin (SPEC section 4).
+ */
+class CoverEndpoint internal constructor(private val baseUrl: String) {
+
+    /**
+     * Resolves the contract's `coverUrl` into a loadable absolute URL. Since contract 1.3.x the
+     * server sends a path relative to its own origin (e.g. `/v1/library/items/{id}/cover`); this
+     * absorbs [baseUrl] so the domain model always carries an absolute, bearer-authenticated URL
+     * and no UI code needs to know the server origin. An already-absolute value passes through
+     * untouched (tolerant reader: contract 1.1.0 documented an absolute URL, a future server could
+     * again send one).
+     */
+    internal fun resolve(coverUrl: String?): String? = when {
+        coverUrl == null -> null
+        coverUrl.startsWith("http://") || coverUrl.startsWith("https://") -> coverUrl
+        else -> baseUrl.trimEnd('/') + (if (coverUrl.startsWith("/")) coverUrl else "/$coverUrl")
+    }
+
+    companion object {
+        // The cover proxy's path shape, mirrored from the contract's `GET
+        // /library/items/{id}/cover`. The generated LibraryApi is regenerated from that contract,
+        // so CoverEndpointTest's drift guard turns red if a contract rename leaves these stale.
+        private const val ITEMS_SEGMENT = "/library/items/"
+        private const val COVER_SUFFIX = "/cover"
+
+        /**
+         * Whether [url] points at the cover endpoint - the only URL shape the `?h=` height
+         * parameter applies to. Matched host- and version-agnostically (path substring only):
+         * knowing the server origin is [resolve]'s concern, not this predicate's, so the app's
+         * cover-image interceptor can stay a lifetime singleton that survives a server change
+         * without rebuilding, an already-absolute cover URL from a future server still matches,
+         * and a `/v1` -> `/v2` bump does not break recognition.
+         */
+        fun matches(url: String): Boolean {
+            val path = url.substringBefore('?')
+            return path.endsWith(COVER_SUFFIX) && path.contains(ITEMS_SEGMENT)
+        }
+    }
+}

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/Mappers.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/Mappers.kt
@@ -46,53 +46,39 @@ internal fun GenSpeaker.toDomain(): Speaker =
 internal fun GenProgress.toDomain(): Progress =
     Progress(positionSeconds = positionSeconds, isFinished = isFinished)
 
-/**
- * Resolves the contract's `coverUrl` into a loadable absolute URL. Since contract 1.3.x the
- * server sends a path relative to its own origin (e.g. `/v1/library/items/{id}/cover`); the
- * wrapper absorbs that here so the domain model always carries an absolute, bearer-authenticated
- * URL and no UI code needs to know the server origin. An already-absolute value passes through
- * untouched (tolerant reader: contract 1.1.0 documented an absolute URL, a future server could
- * again send one).
- */
-internal fun resolveCoverUrl(coverUrl: String?, baseUrl: String): String? = when {
-    coverUrl == null -> null
-    coverUrl.startsWith("http://") || coverUrl.startsWith("https://") -> coverUrl
-    else -> baseUrl.trimEnd('/') + (if (coverUrl.startsWith("/")) coverUrl else "/$coverUrl")
-}
-
-internal fun GenLibraryItemSummary.toDomain(baseUrl: String): LibraryItemSummary =
+internal fun GenLibraryItemSummary.toDomain(cover: CoverEndpoint): LibraryItemSummary =
     LibraryItemSummary(
         id = id,
         title = title,
         author = author,
         durationSeconds = durationSeconds,
-        coverUrl = resolveCoverUrl(coverUrl, baseUrl),
+        coverUrl = cover.resolve(coverUrl),
         progress = progress?.toDomain(),
     )
 
-internal fun GenLibraryItem.toDomain(baseUrl: String): LibraryItem =
+internal fun GenLibraryItem.toDomain(cover: CoverEndpoint): LibraryItem =
     LibraryItem(
         summary = LibraryItemSummary(
             id = id,
             title = title,
             author = author,
             durationSeconds = durationSeconds,
-            coverUrl = resolveCoverUrl(coverUrl, baseUrl),
+            coverUrl = cover.resolve(coverUrl),
             progress = progress?.toDomain(),
         ),
         description = description,
         narrator = narrator,
     )
 
-internal fun GenLibraryItemPage.toDomain(baseUrl: String): LibraryPage =
-    LibraryPage(items = items.map { it.toDomain(baseUrl) }, nextCursor = nextCursor)
+internal fun GenLibraryItemPage.toDomain(cover: CoverEndpoint): LibraryPage =
+    LibraryPage(items = items.map { it.toDomain(cover) }, nextCursor = nextCursor)
 
 /**
  * The in-progress shelf is a complete, bounded set, not a page - the envelope carries no
  * cursor, so it unwraps to a plain list of the existing summary model (no new domain type).
  */
-internal fun GenLibraryItemList.toDomain(baseUrl: String): List<LibraryItemSummary> =
-    items.map { it.toDomain(baseUrl) }
+internal fun GenLibraryItemList.toDomain(cover: CoverEndpoint): List<LibraryItemSummary> =
+    items.map { it.toDomain(cover) }
 
 internal fun GenPlaybackState.toDomain(): PlaybackState = when (this) {
     GenPlaybackState.playing -> PlaybackState.PLAYING
@@ -102,10 +88,10 @@ internal fun GenPlaybackState.toDomain(): PlaybackState = when (this) {
     GenPlaybackState.finished -> PlaybackState.FINISHED
 }
 
-internal fun GenSession.toDomain(baseUrl: String): Session =
+internal fun GenSession.toDomain(cover: CoverEndpoint): Session =
     Session(
         itemId = itemId,
-        item = item?.toDomain(baseUrl),
+        item = item?.toDomain(cover),
         speakerId = speakerId,
         state = state.toDomain(),
         positionSeconds = positionSeconds,

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -45,7 +45,7 @@ class RatatoskrClient internal constructor(
     private val playbackApi: PlaybackApi,
     private val tokenStore: TokenAccess,
     private val moshi: Moshi,
-    private val baseUrl: String,
+    private val coverEndpoint: CoverEndpoint,
     /**
      * OkHttp stack for loading cover images, sharing this client's TLS trust (TOFU pin,
      * SPEC section 6) and bearer/refresh auth (SPEC section 5) but with its own dispatcher,
@@ -85,7 +85,7 @@ class RatatoskrClient internal constructor(
         limit: Int? = null,
         cursor: String? = null,
     ): ApiResult<LibraryPage> =
-        execute { libraryApi.listLibraryItems(query, limit, cursor) }.map { it.toDomain(baseUrl) }
+        execute { libraryApi.listLibraryItems(query, limit, cursor) }.map { it.toDomain(coverEndpoint) }
 
     /**
      * The continue-listening shelf: in-progress books, most-recently-listened first. Membership
@@ -94,14 +94,14 @@ class RatatoskrClient internal constructor(
      * overridden with null here).
      */
     suspend fun listInProgressItems(): ApiResult<List<LibraryItemSummary>> =
-        execute { libraryApi.listInProgressItems(limit = null) }.map { it.toDomain(baseUrl) }
+        execute { libraryApi.listInProgressItems(limit = null) }.map { it.toDomain(coverEndpoint) }
 
     suspend fun getLibraryItem(itemId: String): ApiResult<LibraryItem> =
-        execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain(baseUrl) }
+        execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain(coverEndpoint) }
 
     suspend fun currentSession(): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.getCurrentSession() }
-            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
+            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
 
     /**
      * Starts playback. The stored refresh token is handed to the server so its sync loop can
@@ -112,7 +112,7 @@ class RatatoskrClient internal constructor(
         val refreshToken = tokenStore.refreshToken()
         return execute {
             playbackApi.startSession(StartSessionRequest(itemId, speakerId, refreshToken))
-        }.adoptingRotatedTokens().map { it.toDomain(baseUrl) }
+        }.adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
     }
 
     /**
@@ -132,15 +132,15 @@ class RatatoskrClient internal constructor(
 
     suspend fun pause(): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.pauseSession() }
-            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
+            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
 
     suspend fun resume(): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.resumeSession() }
-            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
+            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
 
     suspend fun seek(positionSeconds: Double): ApiResult<Session> =
         execute(sessionEndpoint = true) { playbackApi.seekSession(SeekRequest(positionSeconds)) }
-            .adoptingRotatedTokens().map { it.toDomain(baseUrl) }
+            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
 
     // --- token adoption -----------------------------------------------------------------
 

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientFactory.kt
@@ -142,7 +142,7 @@ object RatatoskrClientFactory {
             playbackApi = mainRetrofit.create(PlaybackApi::class.java),
             tokenStore = tokenStore,
             moshi = moshi,
-            baseUrl = baseUrl,
+            coverEndpoint = CoverEndpoint(baseUrl),
             coversCallFactory = coversClient,
             closeAction = closeAction,
         )

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/CoverEndpointTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/CoverEndpointTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.http.GET
+
+class CoverEndpointTest {
+
+    private val endpoint = CoverEndpoint("https://ratatoskr.home:8080")
+
+    // --- resolve: contract 1.3.x sends a path relative to the server origin; the wrapper
+    // --- absorbs that so the domain model always carries a loadable URL --------------------
+
+    @Test
+    fun `relative coverUrl resolves against the base url`() {
+        assertEquals(
+            "https://ratatoskr.home:8080/v1/library/items/42/cover",
+            endpoint.resolve("/v1/library/items/42/cover"),
+        )
+    }
+
+    @Test
+    fun `trailing slash on the base url does not double the separator`() {
+        assertEquals(
+            "https://ratatoskr.home:8080/v1/library/items/42/cover",
+            CoverEndpoint("https://ratatoskr.home:8080/").resolve("/v1/library/items/42/cover"),
+        )
+    }
+
+    @Test
+    fun `absolute coverUrl passes through untouched`() {
+        // Pins the tolerant-reader branch documented on CoverEndpoint.resolve: an already-absolute
+        // value is never re-prefixed.
+        assertEquals(
+            "https://elsewhere.example/cover.jpg",
+            endpoint.resolve("https://elsewhere.example/cover.jpg"),
+        )
+    }
+
+    @Test
+    fun `null coverUrl stays null`() {
+        assertEquals(null, endpoint.resolve(null))
+    }
+
+    // --- matches: host- and version-agnostic recognition of the cover endpoint -------------
+
+    @Test
+    fun `matches the canonical cover path`() {
+        assertTrue(CoverEndpoint.matches("https://ratatoskr.home:8080/v1/library/items/42/cover"))
+    }
+
+    @Test
+    fun `matches with a query string present`() {
+        assertTrue(CoverEndpoint.matches("https://ratatoskr.home:8080/v1/library/items/42/cover?h=256"))
+    }
+
+    @Test
+    fun `matches regardless of the version prefix`() {
+        assertTrue(CoverEndpoint.matches("https://ratatoskr.home:8080/library/items/42/cover"))
+    }
+
+    @Test
+    fun `does not match a non-cover image`() {
+        assertFalse(CoverEndpoint.matches("https://ratatoskr.home:8080/img/banner.png"))
+    }
+
+    @Test
+    fun `does not match a cover suffix outside the items path`() {
+        assertFalse(CoverEndpoint.matches("https://ratatoskr.home:8080/cover"))
+    }
+
+    // --- drift guard: matches must recognise the endpoint the generated client (regenerated
+    // --- from the contract) actually declares - a contract rename turns this red ------------
+
+    @Test
+    fun `matches the cover path declared by the generated contract client`() {
+        val libraryApi = Class.forName("io.github.xexanos.ratatoskr.network.generated.api.LibraryApi")
+        val coverPath = libraryApi.methods.single { it.name == "getLibraryItemCover" }
+            .getAnnotation(GET::class.java)!!.value
+        val relative = coverPath.replace("{itemId}", "sample-id")
+
+        val resolved = endpoint.resolve(relative)!!
+
+        assertTrue(
+            "CoverEndpoint.matches must recognise the contract cover path '$relative'; " +
+                "update CoverEndpoint if the contract renamed the endpoint",
+            CoverEndpoint.matches(resolved),
+        )
+    }
+}

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/MappersTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/MappersTest.kt
@@ -35,7 +35,7 @@ class MappersTest {
             narrator = "Andy Serkis",
         )
 
-        val domain = gen.toDomain(baseUrl = "https://ratatoskr.home:8080")
+        val domain = gen.toDomain(CoverEndpoint("https://ratatoskr.home:8080"))
 
         assertEquals("42", domain.summary.id)
         assertEquals("The Hobbit", domain.summary.title)
@@ -43,40 +43,6 @@ class MappersTest {
         assertEquals(120.5, domain.summary.progress!!.positionSeconds, 0.0)
         assertEquals("There and back again", domain.description)
         assertEquals("Andy Serkis", domain.narrator)
-    }
-
-    // --- coverUrl resolution (contract 1.3.x sends a path relative to the server origin;
-    // --- the wrapper absorbs that so the domain model always carries a loadable URL) --------
-
-    @Test
-    fun `relative coverUrl resolves against the base url`() {
-        assertEquals(
-            "https://ratatoskr.home:8080/v1/library/items/42/cover",
-            resolveCoverUrl("/v1/library/items/42/cover", "https://ratatoskr.home:8080"),
-        )
-    }
-
-    @Test
-    fun `trailing slash on the base url does not double the separator`() {
-        assertEquals(
-            "https://ratatoskr.home:8080/v1/library/items/42/cover",
-            resolveCoverUrl("/v1/library/items/42/cover", "https://ratatoskr.home:8080/"),
-        )
-    }
-
-    @Test
-    fun `absolute coverUrl passes through untouched`() {
-        // Tolerant-reader guard: contract 1.1.0 described the field as an absolute URL, and a
-        // future server could return to that. Never re-prefix an already-absolute value.
-        assertEquals(
-            "https://elsewhere.example/cover.jpg",
-            resolveCoverUrl("https://elsewhere.example/cover.jpg", "https://ratatoskr.home:8080"),
-        )
-    }
-
-    @Test
-    fun `null coverUrl stays null`() {
-        assertEquals(null, resolveCoverUrl(null, "https://ratatoskr.home:8080"))
     }
 
     @Test
@@ -88,7 +54,7 @@ class MappersTest {
             coverUrl = "/v1/library/items/42/cover",
         )
 
-        val domain = gen.toDomain(baseUrl = "https://ratatoskr.home:8080")
+        val domain = gen.toDomain(CoverEndpoint("https://ratatoskr.home:8080"))
 
         assertEquals("https://ratatoskr.home:8080/v1/library/items/42/cover", domain.coverUrl)
     }

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -53,7 +53,7 @@ class RatatoskrClientTest {
             playbackApi = retrofit.create(PlaybackApi::class.java),
             tokenStore = tokens,
             moshi = moshi,
-            baseUrl = server.url("/").toString(),
+            coverEndpoint = CoverEndpoint(server.url("/").toString()),
             coversCallFactory = OkHttpClient(),
         )
     }


### PR DESCRIPTION
## What

Concentrate everything the app knows about the server's cover endpoint into one deep module, `CoverEndpoint` (core-network, `api/` layer).

Before, that knowledge lived in three places across two Gradle modules with no shared source:

- `resolveCoverUrl` (core-network mappers) — relative→absolute resolution
- `isCoverUrl` (app `CoverHeightInterceptor`) — re-deriving the cover path shape as a string heuristic
- `baseUrl` threaded through every cover-bearing mapper signature to feed the resolver

## Change

`CoverEndpoint`:

- `resolve(coverUrl)` — relative→absolute, `baseUrl` bound once, tolerant reader for already-absolute URLs (moved from `resolveCoverUrl`)
- `matches(url)` — host- and version-agnostic path-shape recognition, a public companion the app's interceptor consumes instead of its own heuristic (moved from `isCoverUrl`)

The five cover-bearing mappers now take a `CoverEndpoint` instead of a raw `baseUrl: String`, so a relative cover URL can only be produced through the resolver — the "never emit a relative URL above the wrapper" invariant becomes type-enforced rather than convention-enforced. `RatatoskrClient` holds a `CoverEndpoint`; the factory builds it once.

Height/bucket policy (`?h=`, `CoverHeightBuckets`) deliberately stays in the app module — it is client rendering policy on a different change axis.

## Behaviour

Unchanged. `resolve`/`matches` are the old bodies moved as-is.

## Tests

- **Drift guard**: reflects the generated `LibraryApi.getLibraryItemCover` `@GET` path, runs it through `resolve`, and asserts `matches` still recognises it — a contract rename of the cover path turns the build red.
- `matches` unit tests (canonical, with query, no version prefix; negatives).
- First `CoverHeightInterceptor` test (cover URL gets `?h=<bucket>`; non-cover untouched).
- Existing `resolveCoverUrl` cases moved from `MappersTest` to `CoverEndpointTest`.

All JVM unit tests pass (`:core-network:testDebugUnitTest`, `:app:testDebugUnitTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
