### PR TITLE
test: settle LibraryViewModelTest's cancelled scopes before resetMain

### DIFF
--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/library/LibraryViewModelTest.kt
@@ -24,7 +24,7 @@ import io.github.xexanos.ratatoskr.ui.UiError
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -82,12 +82,25 @@ class LibraryViewModelTest {
 
     @After
     fun tearDown() {
-        createdViewModels.forEach { it.viewModelScope.cancel() }
-        // cancel() only marks the collector's Job; it doesn't itself run on this thread, so it
-        // needs this test's own dispatcher pumped once more before resetMain() detaches it -
-        // otherwise the cancellation can still be "pending" when Main is torn down, and a later
-        // test's UncaughtExceptionsBeforeTest attributes the failure to whatever runs next.
-        dispatcher.scheduler.advanceUntilIdle()
+        // cancel() only MARKS each scope's Job; the cancellation itself - and the
+        // CancellationException resuming whatever real work (an OkHttp round trip, a DataStore
+        // write) a collector is parked on - still has to run, and it resumes on Main (this
+        // virtual dispatcher). A bare advanceUntilIdle() drains only what is queued at that
+        // instant: a request still in flight completes later, on its own OkHttp thread, and then
+        // dispatches its continuation onto a Main that resetMain() has already detached - which
+        // throws, uncaught, and a later test's UncaughtExceptionsBeforeTest inherits it (the
+        // failure this class has hit on its first test). So drain the virtual queue and let the
+        // real threads make progress in lockstep (the same alternation as settleState) until
+        // every cancelled scope has actually COMPLETED - only then detach Main.
+        val jobs = createdViewModels.map { it.viewModelScope.coroutineContext[Job]!! }
+        jobs.forEach { it.cancel() }
+        val deadline = System.currentTimeMillis() + 10_000
+        while (jobs.any { !it.isCompleted }) {
+            dispatcher.scheduler.advanceUntilIdle()
+            if (jobs.all { it.isCompleted }) break
+            check(System.currentTimeMillis() < deadline) { "viewModelScope did not settle in teardown" }
+            Thread.sleep(10)
+        }
         Dispatchers.resetMain()
     }
 


### PR DESCRIPTION
## What & why

`main` went red on the **CI → Build & unit test** job (commit `459cac3`, the merge of #106):

```
LibraryViewModelTest > initial load fetches the full library without a query FAILED
    kotlinx.coroutines.test.UncaughtExceptionsBeforeTest at LibraryViewModelTest.kt:193
135 tests completed, 1 failed
```

**This is a flaky test, not an app bug.** The same code was green on the PR head (`29755b2`) and red on the merge commit (`459cac3`) — the signature of a race, and `UncaughtExceptionsBeforeTest` is a test-harness artifact by construction: it reports an uncaught exception that leaked from a coroutine *before* the current test's `runTest` even started, then blames whichever test runs next (here the first-declared one, `initial load…`).

### Root cause

`LibraryViewModel`'s coroutines run on a **virtual** `StandardTestDispatcher` (installed as `Dispatchers.Main`), but the ViewModel does **real** async work — OkHttp round-trips against `HttpsMockServer`, plus the permanent `sessionManager.state` collector (ADR 0002). `tearDown` cancelled each `viewModelScope` and called `advanceUntilIdle()`, but that only drains the *virtual* queue at that instant. A request still in flight completes **later, on its own OkHttp thread**, and then dispatches its continuation onto a `Main` that `resetMain()` has already detached — which throws, uncaught, and the next test inherits it.

Commit `62b76f6` already fought this exact failure and narrowed the window, but did not close it (its message claims a real-thread drain that the diff never actually added — only `advanceUntilIdle()` was added).

### Fix

In `tearDown`, drain the virtual queue and let the real threads make progress **in lockstep** — the same alternation the file's own `settleState` helper already uses — until every cancelled scope has actually **completed**, and only then `resetMain()`. A 10 s guard fails loudly rather than hanging if a scope never settles.

Test-only, no production change. `LibraryScreen`/`LibraryViewModel` are untouched, so the app's behavior is unchanged.

## Testing

I could not run the JVM suite in this environment (the required Gradle 9.6.1 distribution download is blocked by the network policy, and the locally available Gradle 8.14.3 is too old for AGP 9.3.0). **CI is the executable check for this change.** The fix is localized to the `@After` teardown and mirrors the proven `settleState` pattern already used throughout the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEqU8QmxvmkxGNVYz3wQ9M)_