### PR TITLE
ci: surface the cross-repo E2E verdict as a commit status

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -45,6 +45,11 @@ permissions:
   # Needed to create the per-commit testing-* pre-releases and their tags, and to delete
   # stale ones in the scheduled cleanup job.
   contents: write
+  # Post an "e2e" commit status on the validated commit so the cross-repo E2E result (the run
+  # happens in Xexanos/ratatoskr-e2e, invisible here otherwise) shows up on this commit. This
+  # job sets it to pending right after dispatch; the E2E run overwrites it with success/failure
+  # via the same context. Same-repo status write, so the built-in GITHUB_TOKEN suffices.
+  statuses: write
 
 concurrency:
   # Scope by event so the scheduled cleanup and a push validation never cancel each other.
@@ -197,6 +202,26 @@ jobs:
             -f event_type=app-candidate \
             -F "client_payload[release_tag]=${RELEASE_TAG}" \
             -F "client_payload[commit]=${SHA}"
+
+      # Surface that dispatch on this commit straight away: a pending "e2e" status the E2E suite
+      # overwrites with success/failure when it finishes (same context, same commit), so the
+      # cross-repo verdict is visible here without opening ratatoskr-e2e. Informational only -
+      # a failed status POST must never fail the pipeline (unlike the dispatch above, whose
+      # failure is deliberately loud), so this only warns.
+      - name: Mark the E2E status pending on this commit
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          SHA: ${{ github.sha }}
+          E2E_ACTIONS_URL: ${{ github.server_url }}/${{ github.repository_owner }}/ratatoskr-e2e/actions
+        run: |
+          gh api "repos/${OWNER}/ratatoskr-app/statuses/${SHA}" \
+            -f state=pending \
+            -f context=e2e \
+            -f description="Cross-component E2E dispatched, awaiting result" \
+            -f target_url="${E2E_ACTIONS_URL}" \
+            || echo "::warning title=E2E status::could not set the pending commit status (visibility only; pipeline unaffected)."
 
   # Prune the per-commit testing-* pre-releases so they do not accumulate forever. Runs only
   # on the daily schedule (or a manual dispatch); deletes any testing-* pre-release older than


### PR DESCRIPTION
## What

The cross-component E2E suite runs in **Xexanos/ratatoskr-e2e** (dispatched post-merge by `release-validation.yml`), so its verdict was invisible from this repo — you had to open the other repo to see whether the `p1-spine` flow passed. This surfaces it as a commit status.

Right after dispatching the suite, this sets a **pending `e2e` commit status** on the validated commit. When the E2E run finishes it overwrites that status with **success/failure** (same context, done from `ratatoskr-e2e`), linking back to the run. Result: a yellow→green/red `e2e` check on the main commit (and on any PR checks).

## Change

- `statuses: write` added to the job permissions.
- A `Mark the E2E status pending on this commit` step after the dispatch. Same-repo status write → the built-in `GITHUB_TOKEN` is enough, **no PAT**. Informational only: a failed status POST warns, never fails the pipeline.

## Paired PRs (all three needed together)

- **ratatoskr-e2e** — posts the final success/failure verdict back onto the commit.
- **ratatoskr-server** — same pending-status pattern for the server's own E2E dispatch.

## ⚠️ Action required (token scope)

The final verdict is posted from `ratatoskr-e2e` using the existing `APP_PROMOTE_TOKEN`. That token now also needs **`statuses: write` (Commit statuses)** on `ratatoskr-app`. A classic PAT with `repo` scope already covers it; a fine-grained token needs the permission added. Without it, the pending status is set but never resolves (harmless, just no green/red).

Follow-up to the #108 investigation, where the invisible E2E gate made the regression hard to spot.
