### PR TITLE
refactor(auth): narrow the app-to-network auth-token coupling ahead of /v2 (#117)

### DIFF
--- a/app/src/main/java/io/github/xexanos/ratatoskr/MainActivity.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/MainActivity.kt
@@ -80,8 +80,8 @@ class MainActivity : ComponentActivity() {
     /**
      * Launch routing (SPEC section 13): no trusted server -> connect; no stored tokens ->
      * sign-in; otherwise the library. Runs off the main thread: on a cold start the DataStore
-     * reads and the Keystore-backed decrypt in authSession() are blocking, so resolving this
-     * inside onCreate would risk dropped launch frames or an ANR.
+     * reads and the Keystore-backed decrypt behind hasCredential() are blocking, so resolving
+     * this inside onCreate would risk dropped launch frames or an ANR.
      */
     private suspend fun decideStartDestination(container: AppContainer): Route =
         withContext(Dispatchers.IO) {
@@ -89,7 +89,7 @@ class MainActivity : ComponentActivity() {
                 container.connectionStore.fingerprint() != null
             when {
                 !hasTrustedServer -> Route.Connect
-                container.tokenStore.authSession() == null -> Route.SignIn
+                !container.credentialStore.hasCredential() -> Route.SignIn
                 else -> Route.Library
             }
         }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/data/ConnectionManager.kt
@@ -8,6 +8,7 @@ package io.github.xexanos.ratatoskr.data
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClient
 import io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
+import io.github.xexanos.ratatoskr.network.persist.CredentialStore
 import io.github.xexanos.ratatoskr.network.persist.TokenAccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -17,7 +18,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Owns the current [RatatoskrClient], rebuilding it whenever the trusted server or its
@@ -26,11 +26,20 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 class ConnectionManager(
     val connectionStore: ConnectionStore,
+    // The pair-shaped network handle: passed to the factory (which needs the bearer/refresh
+    // tokens) and used by the tests. App code goes through [credentials], never the pair.
     val tokenStore: TokenAccess,
 ) {
-    // While a playback session is active the server owns refresh-token rotation, so the
-    // client must not refresh independently (SPEC section 5).
-    private val sessionActive = AtomicBoolean(false)
+    /**
+     * The credential-shaped seam app code uses for auth state (SPEC section 5): a presence check
+     * and a clear, nothing pair-shaped. Backed by [tokenStore]; the /v2 cutover reshapes what is
+     * behind this without touching the callers.
+     */
+    val credentials: CredentialStore get() = tokenStore
+
+    // While a playback session is active the server owns refresh-token rotation, so the client
+    // must not refresh independently (SPEC section 5). Isolated in one deletable feed:
+    private val refreshSuppression = RefreshSuppression()
 
     // Guards client construction so concurrent callers (e.g. the poll loop and a screen right
     // after sign-in) cannot each build a client. Two OkHttp stacks would each hold their own
@@ -55,16 +64,16 @@ class ConnectionManager(
     private val _reauthRequired = MutableStateFlow(false)
     val reauthRequired: StateFlow<Boolean> = _reauthRequired.asStateFlow()
 
-    fun setSessionActive(active: Boolean) = sessionActive.set(active)
+    fun setSessionActive(active: Boolean) = refreshSuppression.setSessionActive(active)
 
     /**
-     * Terminal auth failure: stop suppressing refresh, discard the stranded tokens, and signal
-     * the UI to send the user back to sign-in. Idempotent - safe to call from several failing
-     * calls at once. Cleared by [acknowledgeReauth] once the nav host has routed.
+     * Terminal auth failure: stop suppressing refresh, discard the stranded credential, and
+     * signal the UI to send the user back to sign-in. Idempotent - safe to call from several
+     * failing calls at once. Cleared by [acknowledgeReauth] once the nav host has routed.
      */
     suspend fun requireReauth() {
-        sessionActive.set(false)
-        tokenStore.clear()
+        refreshSuppression.setSessionActive(false)
+        credentials.clear()
         _reauthRequired.value = true
     }
 
@@ -83,7 +92,7 @@ class ConnectionManager(
     fun peekClient(): RatatoskrClient? = cached?.client
 
     /** Whether a playback session is currently active - gates client-side token refresh (SPEC section 5). */
-    fun isSessionActive(): Boolean = sessionActive.get()
+    fun isSessionActive(): Boolean = refreshSuppression.isSessionActive()
 
     /** The client for the currently trusted server, or null if none is configured yet. */
     suspend fun client(): RatatoskrClient? {
@@ -100,7 +109,7 @@ class ConnectionManager(
                 baseUrl = config.baseUrl,
                 fingerprint = fingerprint,
                 tokenStore = tokenStore,
-                sessionActive = { sessionActive.get() },
+                sessionActive = refreshSuppression.suppressed,
             ).also {
                 cached = Cached(key, it)
             }

--- a/app/src/main/java/io/github/xexanos/ratatoskr/data/RefreshSuppression.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/data/RefreshSuppression.kt
@@ -1,0 +1,31 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.data
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The /v1 refresh-suppression feed (SPEC section 5), isolated in one type so the /v2 cutover
+ * deletes it wholesale. While a playback session is active the server owns refresh-token
+ * rotation, so the OkHttp authenticator must not run the app's own `/auth/refresh` and race the
+ * server for the same rotating token. [SessionManager] raises and lowers the flag as the session
+ * comes and goes; [RatatoskrClientFactory][io.github.xexanos.ratatoskr.network.api.RatatoskrClientFactory]
+ * reads [suppressed] into the authenticator.
+ *
+ * On /v2 there is no rotation and no suppression: this whole feed - the flag, its accessors, the
+ * factory's `sessionActive` parameter, and [SessionManager]'s calls into it - is removed.
+ */
+class RefreshSuppression {
+
+    private val active = AtomicBoolean(false)
+
+    fun setSessionActive(active: Boolean) = this.active.set(active)
+
+    fun isSessionActive(): Boolean = active.get()
+
+    /** The read the client factory hands to the authenticator (a plain background-thread poll). */
+    val suppressed: () -> Boolean = ::isSessionActive
+}

--- a/app/src/main/java/io/github/xexanos/ratatoskr/di/AppContainer.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/di/AppContainer.kt
@@ -15,6 +15,7 @@ import io.github.xexanos.ratatoskr.covers.CoverImages
 import io.github.xexanos.ratatoskr.data.ConnectionManager
 import io.github.xexanos.ratatoskr.data.SessionManager
 import io.github.xexanos.ratatoskr.data.SpeakerManager
+import io.github.xexanos.ratatoskr.network.persist.CredentialStore
 import io.github.xexanos.ratatoskr.network.persist.DataStoreConnectionStore
 import io.github.xexanos.ratatoskr.network.persist.KeystoreCrypto
 import io.github.xexanos.ratatoskr.network.persist.TokenStore
@@ -36,7 +37,13 @@ class AppContainer(context: Context) {
         PreferenceDataStoreFactory.create { appContext.preferencesDataStoreFile("tokens") }
 
     val connectionStore = DataStoreConnectionStore(connectionDataStore)
-    val tokenStore = TokenStore(tokenDataStore, KeystoreCrypto())
+
+    // The Keystore-backed store is the network module's pair-shaped handle; the factory (via
+    // ConnectionManager) needs it. The rest of the app sees only the credential-shaped
+    // [credentialStore] view of the same instance, never the token pair (SPEC section 5).
+    private val tokenStore = TokenStore(tokenDataStore, KeystoreCrypto())
+    val credentialStore: CredentialStore = tokenStore
+
     val certificateInspector = CertificateInspector()
     val connectionManager = ConnectionManager(connectionStore, tokenStore)
     val coverImages = CoverImages(appContext) { connectionManager.peekClient()?.coversCallFactory }
@@ -57,7 +64,7 @@ class AppContainer(context: Context) {
      */
     suspend fun reset() {
         connectionStore.clear()
-        tokenStore.clear()
+        credentialStore.clear()
         connectionManager.invalidate()
         coverImages.clear()
         sessionManager.reset()

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
@@ -86,7 +86,7 @@ class SettingsViewModel(
 
     fun signOut() {
         viewModelScope.launch {
-            connectionManager.tokenStore.clear()
+            connectionManager.credentials.clear()
             clearCoverCache()
             _uiState.value = _uiState.value.copy(signedOut = true)
         }

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -57,6 +57,10 @@ class RatatoskrClient internal constructor(
     private val closeAction: () -> Unit = {},
 ) {
 
+    // The /v1 refresh-token rotation-adoption protocol (SPEC section 5), behind one seam the /v2
+    // cutover deletes. Every session-returning call routes its result through it.
+    private val rotation = SessionRotationAdoption(tokenStore)
+
     /**
      * Releases the underlying OkHttp resources (dispatcher threads and pooled sockets). Call
      * when this client is replaced - the owner does so on a server/certificate change - so the
@@ -100,8 +104,8 @@ class RatatoskrClient internal constructor(
         execute { libraryApi.getLibraryItem(itemId) }.map { it.toDomain(coverEndpoint) }
 
     suspend fun currentSession(): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.getCurrentSession() }
-            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
+        rotation.adopt(execute(sessionEndpoint = true) { playbackApi.getCurrentSession() })
+            .map { it.toDomain(coverEndpoint) }
 
     /**
      * Starts playback. The stored refresh token is handed to the server so its sync loop can
@@ -109,10 +113,10 @@ class RatatoskrClient internal constructor(
      * StartSessionRequest.refreshToken).
      */
     suspend fun startSession(itemId: String, speakerId: String): ApiResult<Session> {
-        val refreshToken = tokenStore.refreshToken()
-        return execute {
-            playbackApi.startSession(StartSessionRequest(itemId, speakerId, refreshToken))
-        }.adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
+        val refreshToken = rotation.refreshTokenForHandoff()
+        return rotation.adopt(
+            execute { playbackApi.startSession(StartSessionRequest(itemId, speakerId, refreshToken)) },
+        ).map { it.toDomain(coverEndpoint) }
     }
 
     /**
@@ -124,40 +128,24 @@ class RatatoskrClient internal constructor(
     suspend fun stopSession(): ApiResult<Unit> =
         when (val result = executeNullable(sessionEndpoint = true) { playbackApi.stopSession() }) {
             is ApiResult.Success -> {
-                result.data?.adoptRotatedTokens()
+                rotation.adopt(result.data)
                 ApiResult.Success(Unit)
             }
             is ApiResult.Failure -> result
         }
 
     suspend fun pause(): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.pauseSession() }
-            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
+        rotation.adopt(execute(sessionEndpoint = true) { playbackApi.pauseSession() })
+            .map { it.toDomain(coverEndpoint) }
 
     suspend fun resume(): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.resumeSession() }
-            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
+        rotation.adopt(execute(sessionEndpoint = true) { playbackApi.resumeSession() })
+            .map { it.toDomain(coverEndpoint) }
 
     suspend fun seek(positionSeconds: Double): ApiResult<Session> =
-        execute(sessionEndpoint = true) { playbackApi.seekSession(SeekRequest(positionSeconds)) }
-            .adoptingRotatedTokens().map { it.toDomain(coverEndpoint) }
-
-    // --- token adoption -----------------------------------------------------------------
-
-    /**
-     * Adopts a rotated token pair carried on a successful [GenSession] response and passes the
-     * result through unchanged. This is how the app learns the tokens the server rotated during
-     * an active session, since it does not refresh on its own while a session is live
-     * (SPEC section 5).
-     */
-    private suspend fun ApiResult<GenSession>.adoptingRotatedTokens(): ApiResult<GenSession> {
-        (this as? ApiResult.Success)?.data?.adoptRotatedTokens()
-        return this
-    }
-
-    private suspend fun GenSession.adoptRotatedTokens() {
-        rotatedTokens?.let { tokenStore.updateTokens(it.accessToken, it.refreshToken) }
-    }
+        rotation.adopt(
+            execute(sessionEndpoint = true) { playbackApi.seekSession(SeekRequest(positionSeconds)) },
+        ).map { it.toDomain(coverEndpoint) }
 
     // --- error handling -----------------------------------------------------------------
 

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/SessionRotationAdoption.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/SessionRotationAdoption.kt
@@ -1,0 +1,47 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.api
+
+import io.github.xexanos.ratatoskr.network.domain.ApiResult
+import io.github.xexanos.ratatoskr.network.persist.TokenAccess
+import io.github.xexanos.ratatoskr.network.generated.model.Session as GenSession
+
+/**
+ * The /v1 refresh-token rotation-adoption protocol (SPEC section 5), isolated in one type so the
+ * /v2 cutover deletes it wholesale.
+ *
+ * While a playback session is active the app does not run its own refresh (the server owns the
+ * rotation); instead it *adopts* the tokens the server rotated, which ride back on the session
+ * responses. And at start it hands the server the current refresh token so the server's sync
+ * loop can rotate during long unattended playback (contract `StartSessionRequest.refreshToken`).
+ *
+ * On /v2 there is no rotation: the credential is a single non-expiring token, this whole seam is
+ * removed, and [RatatoskrClient]'s playback calls become plain request/response mappings.
+ */
+internal class SessionRotationAdoption(private val tokenStore: TokenAccess) {
+
+    /** The refresh token handed to the server at `startSession`, or null if none is stored. */
+    suspend fun refreshTokenForHandoff(): String? = tokenStore.refreshToken()
+
+    /**
+     * Adopts a rotated pair carried on a successful session response and passes the result
+     * through unchanged, so callers can keep mapping the body: this is how the app learns the
+     * tokens the server rotated during an active session.
+     */
+    suspend fun adopt(result: ApiResult<GenSession>): ApiResult<GenSession> {
+        (result as? ApiResult.Success)?.data?.let { adopt(it) }
+        return result
+    }
+
+    /**
+     * Adopts a rotated pair from a (possibly absent) session body - e.g. `stopSession`'s
+     * 200-with-Session form, whose pair must be taken before the session ends since the server
+     * discards its in-memory tokens on stop and cannot redeliver them.
+     */
+    suspend fun adopt(session: GenSession?) {
+        session?.rotatedTokens?.let { tokenStore.updateTokens(it.accessToken, it.refreshToken) }
+    }
+}

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/domain/Models.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/domain/Models.kt
@@ -40,6 +40,19 @@ data class AuthSession(
     val user: AuthUser,
 )
 
+/**
+ * The app's single, opaque auth credential (SPEC section 5). The app module treats it as a
+ * black box: it only checks presence (signed in or not) and clears it on sign-out, and the
+ * [value] never leaves core-network - its constructor and field are `internal`, so no
+ * cross-module caller can read or forge it.
+ *
+ * On the /v1 contract this projects the stored token pair to the bearer the client sends; the
+ * /v2 cutover makes it the one stored Ratatoskr token, with no change on the app side. It is
+ * the stable, credential-shaped seam the cutover swaps behind (SPEC section 5).
+ */
+@JvmInline
+value class Credential internal constructor(internal val value: String)
+
 data class Speaker(
     val id: String,
     val name: String,

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/persist/CredentialStore.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/persist/CredentialStore.kt
@@ -1,0 +1,30 @@
+/*
+ * Ratatoskr Android app
+ * Copyright (C) 2026  Ratatoskr contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package io.github.xexanos.ratatoskr.network.persist
+
+import io.github.xexanos.ratatoskr.network.domain.Credential
+
+/**
+ * The credential-shaped seam the app module depends on for auth state (SPEC section 5): it can
+ * ask whether a credential is stored and discard it, and nothing more. The app never sees the
+ * token pair behind it, so the /v2 cutover - which collapses that pair into one non-expiring
+ * Ratatoskr token - changes only the [TokenAccess] implementation below this line, not a single
+ * app-module caller.
+ */
+interface CredentialStore {
+
+    /** The stored credential, or null when signed out. Opaque: callers only compare it to null. */
+    suspend fun credential(): Credential?
+
+    /**
+     * Whether a credential is stored - the launch-routing "is the user signed in?" check
+     * (SPEC section 13). Presence mirrors [credential], so it stays exact across the cutover.
+     */
+    suspend fun hasCredential(): Boolean = credential() != null
+
+    /** Discards the stored credential (sign-out, or a forced re-login). */
+    suspend fun clear()
+}

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/persist/TokenAccess.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/persist/TokenAccess.kt
@@ -6,21 +6,35 @@
 package io.github.xexanos.ratatoskr.network.persist
 
 import io.github.xexanos.ratatoskr.network.domain.AuthSession
+import io.github.xexanos.ratatoskr.network.domain.Credential
 
 /**
- * What the auth plumbing needs from token storage. [TokenStore] is the Keystore-backed
- * implementation; tests use in-memory fakes (SPEC section 9).
+ * What the auth plumbing needs from token storage: the full /v1 token *pair* plus the bearer
+ * read the interceptors use. [TokenStore] is the Keystore-backed implementation; tests use
+ * in-memory fakes (SPEC section 9).
+ *
+ * This is the pair-shaped side of storage - the network module's concern. The app module talks
+ * only to the narrower [CredentialStore] this extends; the /v2 cutover collapses the pair here
+ * into one Ratatoskr token, leaving [CredentialStore]'s callers untouched (SPEC section 5).
  */
-interface TokenAccess {
+interface TokenAccess : CredentialStore {
     suspend fun authSession(): AuthSession?
     suspend fun save(session: AuthSession)
     suspend fun updateTokens(accessToken: String, refreshToken: String)
     suspend fun refreshToken(): String?
-    suspend fun clear()
+    // clear() is inherited from CredentialStore.
 
     /**
      * Blocking read of the current access token, for OkHttp interceptors which run on a
      * background thread and cannot suspend.
      */
     fun currentAccessTokenBlocking(): String?
+
+    /**
+     * The credential-shaped projection of the /v1 pair (SPEC section 5): present exactly when a
+     * full session is stored, its value the bearer the client sends. Implementations that store
+     * the pair get this for free; the /v2 cutover replaces the projection with a direct read of
+     * the single Ratatoskr token.
+     */
+    override suspend fun credential(): Credential? = authSession()?.let { Credential(it.accessToken) }
 }


### PR DESCRIPTION
## What

A **behaviour-preserving prefactor** (issue #117) that narrows how much of the network module's auth/token internals the app module reaches into, so the later `/v2` Ratatoskr-token cutover (#114) is a contained, mechanical swap — *make the change easy, then make the easy change*.

Stacked on `feat/migrate-v2-ratatoskr-token` (targets it, not `main`), on top of the #116 SPEC §5 rewrite.

## Acceptance criteria

- [x] **AC1** — app module no longer reaches into token-pair internals; it talks to a stable, credential-shaped interface (`CredentialStore`).
- [x] **AC2** — the token store exposes a single opaque `Credential` accessor alongside the existing pair storage.
- [x] **AC3** — token-adoption (`SessionRotationAdoption`) and the `sessionActive` suppression feed (`RefreshSuppression`) are each isolated behind one clearly-named seam, ready to delete at the cutover.
- [x] **AC4** — no behaviour change; the full existing test suite passes **unchanged** on the 1.x contract.

## How

- New opaque `Credential` value type (constructor + value `internal`, so no cross-module caller can read or forge it) and a `CredentialStore` seam (`credential()` / `hasCredential()` / `clear()`). `TokenAccess` extends it and projects the /v1 pair to the single credential.
- App code — `MainActivity`, `SettingsViewModel`, `AppContainer`, `ConnectionManager.requireReauth` — routes through the seam instead of `authSession()` / `tokenStore.clear()`.
- Rotation-adoption moved verbatim into `SessionRotationAdoption`; the refresh-suppression flag+feed into `RefreshSuppression`. Each carries a doc block naming what the /v2 cutover deletes.

## Notes

- `ConnectionManager.tokenStore` stays a public `val`: the pinned `SessionManagerTest` calls `connectionManager.tokenStore.authSession()`, and those tests share the module so `internal` wouldn't hide it. AC4 forces it to stay — the narrowing there is documented convention, not compiler-enforced.
- No test or `FakeTokenAccess` edits (new interface methods have defaults); `git diff` over `*Test*`/`*Fake*` is empty.

## Verification

- ✅ `core-network` + `app` compile (debug)
- ✅ Full JVM unit suite green, unchanged
- ✅ All `androidTest` sources compile against the refactored APIs
- ⚠️ Instrumented tests not run on-device locally (no emulator attached); CI's instrumented jobs cover `FactorySessionRotationComponentTest` etc. The adoption logic moved byte-for-byte, so behaviour is preserved.

Refs #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
