### PR TITLE
feat(auth): sign out via POST /v2/auth/logout, clearing locally regardless

### DIFF
--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -207,6 +207,8 @@ class AppFlowTest {
 
     @Test
     fun signOutFromSettingsReturnsToSignIn() {
+        val dispatcher = RatatoskrDispatcher()
+        useDispatcher(dispatcher)
         connectTrustAndSubmitSignIn()
         compose.awaitTag(UiTestTags.LIBRARY_ROW)
         compose.onNodeWithContentDescription(str(R.string.library_settings)).performClick()
@@ -215,6 +217,9 @@ class AppFlowTest {
         // Signing out clears the tokens and routes back to sign-in.
         compose.awaitText(str(R.string.signin_action))
         compose.onNodeWithText(str(R.string.signin_action)).assertIsDisplayed()
+        // ...and told the server, so the device session is revoked (issue #120). The header
+        // mechanics live in the component layer; here only the flow-level outcome is checked.
+        compose.waitUntil(5_000) { dispatcher.lastLogoutRequest != null }
     }
 
     @Test

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/RatatoskrDispatcher.kt
@@ -53,6 +53,10 @@ class RatatoskrDispatcher(
     @Volatile var lastCoverRequest: RecordedRequest? = null
         private set
 
+    /** The last logout request served, for asserting sign-out told the server. */
+    @Volatile var lastLogoutRequest: RecordedRequest? = null
+        private set
+
     override fun dispatch(request: RecordedRequest): MockResponse {
         val path = request.path.orEmpty().substringBefore('?')
         // A dead token 401s every authenticated route (not /health, not login itself, which mints a
@@ -64,6 +68,10 @@ class RatatoskrDispatcher(
         return when {
             path == "/health" -> jsonResponse("""{"reachable":true}""")
             path == "/v2/auth/login" -> { unauthorizedCode = null; login() }
+            path == "/v2/auth/logout" -> {
+                lastLogoutRequest = request
+                MockResponse().setResponseCode(204)
+            }
             path == "/v2/speakers" -> jsonResponse(speakers)
             // The cover proxy: real PNG bytes so Coil decodes and renders them.
             path.startsWith("/v2/library/items/") && path.endsWith("/cover") -> {

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/settings/SettingsScreen.kt
@@ -86,7 +86,10 @@ class SettingsViewModel(
 
     fun signOut() {
         viewModelScope.launch {
-            connectionManager.credentials.clear()
+            // Through the client so the server revokes the device session too (best-effort,
+            // SPEC section 5); the client clears the stored credential even when the server
+            // is unreachable. Without a client (no trusted server) only local state exists.
+            connectionManager.client()?.signOut() ?: connectionManager.credentials.clear()
             clearCoverCache()
             _uiState.value = _uiState.value.copy(signedOut = true)
         }

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/settings/SettingsViewModelTest.kt
@@ -97,6 +97,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `signOut clears the token store and flips signedOut`() = runTest(dispatcher) {
+        // No trusted server is configured, so this pins the client-less fallback: sign-out
+        // must clear locally even when there is no client to send the logout through. The
+        // logout call itself is covered in core-network (RatatoskrClientTest.signOut...).
         val tokens = FakeTokenAccess(token = "t1")
         val viewModel = SettingsViewModel(connectionManager(tokenStore = tokens), clearCoverCache)
 

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
@@ -15,6 +15,7 @@ import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,6 +43,24 @@ class FactoryAuthComponentTest {
 
         val request = https.takeRequest()
         assertEquals("Bearer t0", request.getHeader("Authorization"))
+    }
+
+    @Test
+    fun signOutSendsTheBearerOnTheLogoutRequest() = runBlocking {
+        https.enqueue204()
+
+        val tokens = FakeTokenAccess(token = "t0")
+        client(tokens).signOut()
+
+        // MockWebServer enforces no auth, so revocation is only proven by the header itself:
+        // logout is the one auth endpoint that REQUIRES the bearer (the server resolves it to
+        // the device session it revokes), which the interceptor's /auth/login-only exemption
+        // must not strip.
+        val request = https.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/v2/auth/logout", request.path)
+        assertEquals("Bearer t0", request.getHeader("Authorization"))
+        assertNull(tokens.currentTokenBlocking())
     }
 
     @Test

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryAuthComponentTest.kt
@@ -52,10 +52,9 @@ class FactoryAuthComponentTest {
         val tokens = FakeTokenAccess(token = "t0")
         client(tokens).signOut()
 
-        // MockWebServer enforces no auth, so revocation is only proven by the header itself:
-        // logout is the one auth endpoint that REQUIRES the bearer (the server resolves it to
-        // the device session it revokes), which the interceptor's /auth/login-only exemption
-        // must not strip.
+        // MockWebServer enforces no auth, so revocation is only proven by asserting the header
+        // itself: without it this test would stay green while the server-side revocation
+        // silently never happens (review discussion on #126).
         val request = https.takeRequest()
         assertEquals("POST", request.method)
         assertEquals("/v2/auth/logout", request.path)

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/AuthInterceptors.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/AuthInterceptors.kt
@@ -10,17 +10,19 @@ import okhttp3.Interceptor
 import okhttp3.Response
 
 /**
- * Attaches the Ratatoskr bearer token to every request except the unauthenticated auth
- * endpoints (SPEC section 5). The token is opaque and non-expiring: it is sent as-is and never
- * refreshed or rotated on the app side, so there is no authenticator here - a 401 is a terminal
- * signal the wrapper surfaces, not something the client can silently recover from.
+ * Attaches the Ratatoskr bearer token to every request except sign-in (SPEC section 5). Login
+ * is the only exempt auth endpoint: logout REQUIRES the bearer - the server resolves the
+ * presented token to the device session it revokes (contract 2.0.0). The token is opaque and
+ * non-expiring: it is sent as-is and never refreshed or rotated on the app side, so there is no
+ * authenticator here - a 401 is a terminal signal the wrapper surfaces, not something the
+ * client can silently recover from.
  */
 class BearerAuthInterceptor(
     private val tokenStore: TokenAccess,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        if (request.url.encodedPath.contains("/auth/")) {
+        if (request.url.encodedPath.endsWith("/auth/login")) {
             return chain.proceed(request)
         }
         val token = tokenStore.currentTokenBlocking()

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -24,6 +24,8 @@ import io.github.xexanos.ratatoskr.network.generated.model.StartSessionRequest
 import io.github.xexanos.ratatoskr.network.generated.model.Error as GenError
 import io.github.xexanos.ratatoskr.network.persist.TokenAccess
 import com.squareup.moshi.Moshi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import retrofit2.Response
 import java.io.IOException
 import java.security.cert.CertificateException
@@ -72,8 +74,23 @@ class RatatoskrClient internal constructor(
         return result
     }
 
+    /**
+     * Signs this device out: tells the server to revoke the token (best-effort - logout is
+     * idempotent and answers 204 even for an unknown token, SPEC section 5) and always clears
+     * the stored credential, whatever the server said. The order matters: the request must go
+     * out while the token is still stored, because the bearer IS what the server resolves to
+     * the device session it revokes.
+     */
     suspend fun signOut() {
-        tokenStore.clear()
+        try {
+            // Best-effort: a Failure result (unreachable server, 5xx, whatever) is deliberately
+            // ignored - the local sign-out below must complete regardless.
+            executeNullable { systemApi.logout() }
+        } finally {
+            // NonCancellable so a caller cancelled mid-request (e.g. a cleared ViewModel scope)
+            // still ends up signed out locally.
+            withContext(NonCancellable) { tokenStore.clear() }
+        }
     }
 
     suspend fun listSpeakers(): ApiResult<List<Speaker>> =

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/BearerAuthInterceptorTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/BearerAuthInterceptorTest.kt
@@ -37,13 +37,26 @@ class BearerAuthInterceptorTest {
     }
 
     @Test
-    fun `does not attach a token to auth endpoints`() {
+    fun `does not attach a token to the login endpoint`() {
         server.enqueue(MockResponse())
         client(FakeTokenAccess(token = "token-1"))
             .newCall(Request.Builder().url(server.url("/v2/auth/login")).build())
             .execute().close()
 
         assertNull(server.takeRequest().getHeader("Authorization"))
+    }
+
+    @Test
+    fun `attaches the bearer token to the logout endpoint`() {
+        // Logout is the one auth endpoint that REQUIRES the bearer: the server resolves the
+        // presented token to the device session it revokes (contract 2.0.0). A blanket /auth/
+        // exemption would send it bare and the revocation would silently never happen.
+        server.enqueue(MockResponse())
+        client(FakeTokenAccess(token = "token-1"))
+            .newCall(Request.Builder().url(server.url("/v2/auth/logout")).build())
+            .execute().close()
+
+        assertEquals("Bearer token-1", server.takeRequest().getHeader("Authorization"))
     }
 
     @Test

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/BearerAuthInterceptorTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/BearerAuthInterceptorTest.kt
@@ -48,9 +48,7 @@ class BearerAuthInterceptorTest {
 
     @Test
     fun `attaches the bearer token to the logout endpoint`() {
-        // Logout is the one auth endpoint that REQUIRES the bearer: the server resolves the
-        // presented token to the device session it revokes (contract 2.0.0). A blanket /auth/
-        // exemption would send it bare and the revocation would silently never happen.
+        // Why logout must carry the bearer: see the BearerAuthInterceptor KDoc.
         server.enqueue(MockResponse())
         client(FakeTokenAccess(token = "token-1"))
             .newCall(Request.Builder().url(server.url("/v2/auth/logout")).build())

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -25,6 +25,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -44,7 +45,9 @@ class RatatoskrClientTest {
         val moshi = ratatoskrMoshi()
         val retrofit = Retrofit.Builder()
             .baseUrl(server.url("/v2/"))
-            .client(OkHttpClient())
+            // Production-shaped auth chain (the factory wires the same interceptor), so the
+            // signOut test can assert the bearer actually rides on the logout request.
+            .client(OkHttpClient.Builder().addInterceptor(BearerAuthInterceptor(tokens)).build())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()
@@ -167,6 +170,41 @@ class RatatoskrClientTest {
         job.cancelAndJoin()
 
         assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun `signOut posts logout with the bearer token and clears the store`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        client.signOut()
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/v2/auth/logout", request.path)
+        // MockWebServer enforces no auth, so the revocation only provably happened if the
+        // bearer is asserted explicitly (review discussion on #126).
+        assertEquals("Bearer t0", request.getHeader("Authorization"))
+        assertNull(tokens.currentTokenBlocking())
+    }
+
+    @Test
+    fun `signOut clears the store even when the server rejects the logout`() = runBlocking {
+        server.enqueue(
+            MockResponse().setResponseCode(500).setBody("""{"code":"boom","message":"broken"}"""),
+        )
+
+        client.signOut()
+
+        assertNull(tokens.currentTokenBlocking())
+    }
+
+    @Test
+    fun `signOut clears the store even when the server is unreachable`() = runBlocking {
+        server.shutdown()
+
+        client.signOut()
+
+        assertNull(tokens.currentTokenBlocking())
     }
 
     @Test

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -181,8 +181,7 @@ class RatatoskrClientTest {
         val request = server.takeRequest()
         assertEquals("POST", request.method)
         assertEquals("/v2/auth/logout", request.path)
-        // MockWebServer enforces no auth, so the revocation only provably happened if the
-        // bearer is asserted explicitly (review discussion on #126).
+        // Asserted explicitly because MockWebServer enforces no auth (see #126).
         assertEquals("Bearer t0", request.getHeader("Authorization"))
         assertNull(tokens.currentTokenBlocking())
     }


### PR DESCRIPTION
Closes #120.

## What

Sign-out now tells the server before clearing locally, and always clears locally regardless of what the server said:

- `RatatoskrClient.signOut()` posts `POST /v2/auth/logout` best-effort, then clears the stored credential in a `finally` under `NonCancellable` - an unreachable server, a 5xx, or a cancelled caller all still end signed out locally.
- `BearerAuthInterceptor`'s blanket `/auth/` exemption is narrowed to `/auth/login`: on contract 2.0.0, logout is the one auth endpoint that **requires** the Authorization header (the server resolves the presented token to the device session it revokes).
- `SettingsViewModel.signOut()` routes through the client so the revocation happens; without a configured client it falls back to the plain local clear.

## Tests

Per the review discussion on #126, MockWebServer enforces no auth, so the bearer on the logout request is asserted explicitly:

- `BearerAuthInterceptorTest`: logout gets the header, login stays exempt.
- `RatatoskrClientTest` (production-shaped interceptor chain): logout request method/path/header + token cleared on 204, on 500, and with the server unreachable.
- `FactoryAuthComponentTest` (instrumented, fully assembled client over TLS): the bearer rides on the logout request.
- `AppFlowTest.signOutFromSettingsReturnsToSignIn` additionally asserts the flow-level outcome that the server received the logout.

All JVM unit tests, lintDebug, and verifyRoborazziDebug green locally; the touched instrumented classes ran green on the local emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)