### PR TITLE
Rollout guard: bare 404 on /v2 routes prompts a server update (#122)

### DIFF
--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -166,6 +166,17 @@ class AppFlowTest {
     }
 
     @Test
+    fun aPreV2ServerAtSignInShowsTheUpdateServerPrompt() {
+        // The rollout guard (SPEC section 5): a server too old to route /v2 answers the login
+        // request with a bare 404. The sign-in screen must show the targeted "update your
+        // server" guidance (with its generic install-an-older-app fallback), not a generic error.
+        useDispatcher(RatatoskrDispatcher(login = { MockResponse().setResponseCode(404) }))
+        connectTrustAndSubmitSignIn()
+        compose.awaitText(str(R.string.error_server_too_old))
+        compose.onAllNodesWithTag(UiTestTags.LIBRARY_ROW).assertCountEquals(0)
+    }
+
+    @Test
     fun emptyLibraryShowsTheEmptyState() {
         useDispatcher(RatatoskrDispatcher(libraryPage = WireFixtures.libraryPageJson(items = emptyList())))
         connectTrustAndSubmitSignIn()

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -167,8 +167,7 @@ class AppFlowTest {
 
     @Test
     fun aPreV2ServerAtSignInShowsTheUpdateServerPrompt() {
-        // The rollout guard (SPEC section 5): a server too old to route /v2 answers the login
-        // request with a bare 404. The sign-in screen must show the targeted "update your
+        // The rollout guard (SPEC section 5): the user must see the targeted "update your
         // server" guidance (with its generic install-an-older-app fallback), not a generic error.
         useDispatcher(RatatoskrDispatcher(login = { MockResponse().setResponseCode(404) }))
         connectTrustAndSubmitSignIn()

--- a/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiError.kt
+++ b/app/src/main/java/io/github/xexanos/ratatoskr/ui/UiError.kt
@@ -39,6 +39,7 @@ fun RatatoskrError.text(): String = when (this) {
     is RatatoskrError.Unauthorized -> stringResource(R.string.error_unauthorized)
     is RatatoskrError.NoActiveSession -> stringResource(R.string.error_no_active_session)
     is RatatoskrError.NotFound -> stringResource(R.string.error_not_found)
+    is RatatoskrError.ServerTooOld -> stringResource(R.string.error_server_too_old)
     is RatatoskrError.Server -> message ?: stringResource(R.string.error_server, httpStatus)
     is RatatoskrError.Upstream -> message ?: stringResource(R.string.error_upstream)
     is RatatoskrError.CertificateUntrusted -> stringResource(R.string.error_cert_untrusted)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,6 +92,7 @@
     <string name="error_unauthorized">Anmeldung abgelaufen. Bitte melde dich erneut an.</string>
     <string name="error_no_active_session">Gerade wird nichts wiedergegeben.</string>
     <string name="error_not_found">Nicht gefunden.</string>
+    <string name="error_server_too_old">Dein Ratatoskr-Server ist zu alt für diese Version der App. Aktualisiere den Server auf 2.0.0 oder neuer. Falls du den Server gerade nicht aktualisieren kannst, installiere stattdessen eine ältere Version dieser App.</string>
     <string name="error_server">Der Server hat einen Fehler gemeldet (%1$d).</string>
     <string name="error_upstream">Audiobookshelf oder Sonos ist nicht verfügbar.</string>
     <string name="error_cert_untrusted">Dem Serverzertifikat wird nicht vertraut. Bestätige es in den Einstellungen erneut, falls es sich geändert hat.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="error_unauthorized">Sign-in expired. Please sign in again.</string>
     <string name="error_no_active_session">Nothing is playing right now.</string>
     <string name="error_not_found">Not found.</string>
+    <string name="error_server_too_old">Your Ratatoskr server is too old for this version of the app. Please update the server to 2.0.0 or newer. If you cannot update it right now, install an earlier version of this app instead.</string>
     <string name="error_server">The server reported an error (%1$d).</string>
     <string name="error_upstream">Audiobookshelf or Sonos is unavailable.</string>
     <string name="error_cert_untrusted">The server certificate is not trusted. Re-confirm it in settings if it changed.</string>

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/auth/SignInViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/auth/SignInViewModelTest.kt
@@ -14,6 +14,7 @@ import io.github.xexanos.ratatoskr.data.ConnectionManager
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.domain.AuthUser
+import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
 import io.github.xexanos.ratatoskr.network.persist.DataStoreConnectionStore
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
@@ -115,6 +116,23 @@ class SignInViewModelTest {
 
         val state = viewModel.uiState.value
         assertTrue("expected Error, was $state", state is SignInUiState.Error)
+    }
+
+    @Test
+    fun `a bare 404 from a pre-v2 server surfaces the server-too-old error`() = runTest(dispatcher) {
+        // The rollout guard (SPEC section 5): a server too old to route /v2 answers the login
+        // route with a bare 404, which must land as the targeted update prompt, not a generic
+        // failure.
+        server.server.enqueue(MockResponse().setResponseCode(404))
+        val viewModel = SignInViewModel(trustedConnectionManager())
+
+        viewModel.signIn("alex", "secret")
+        waitUntil { viewModel.uiState.value != SignInUiState.Submitting }
+
+        assertEquals(
+            SignInUiState.Error(UiError.Domain(RatatoskrError.ServerTooOld)),
+            viewModel.uiState.value,
+        )
     }
 
     @Test

--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/auth/SignInViewModelTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/auth/SignInViewModelTest.kt
@@ -14,7 +14,6 @@ import io.github.xexanos.ratatoskr.data.ConnectionManager
 import io.github.xexanos.ratatoskr.network.FakeTokenAccess
 import io.github.xexanos.ratatoskr.network.WireFixtures
 import io.github.xexanos.ratatoskr.network.domain.AuthUser
-import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
 import io.github.xexanos.ratatoskr.network.persist.ConnectionStore
 import io.github.xexanos.ratatoskr.network.persist.DataStoreConnectionStore
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
@@ -116,23 +115,6 @@ class SignInViewModelTest {
 
         val state = viewModel.uiState.value
         assertTrue("expected Error, was $state", state is SignInUiState.Error)
-    }
-
-    @Test
-    fun `a bare 404 from a pre-v2 server surfaces the server-too-old error`() = runTest(dispatcher) {
-        // The rollout guard (SPEC section 5): a server too old to route /v2 answers the login
-        // route with a bare 404, which must land as the targeted update prompt, not a generic
-        // failure.
-        server.server.enqueue(MockResponse().setResponseCode(404))
-        val viewModel = SignInViewModel(trustedConnectionManager())
-
-        viewModel.signIn("alex", "secret")
-        waitUntil { viewModel.uiState.value != SignInUiState.Submitting }
-
-        assertEquals(
-            SignInUiState.Error(UiError.Domain(RatatoskrError.ServerTooOld)),
-            viewModel.uiState.value,
-        )
     }
 
     @Test

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
@@ -63,6 +63,17 @@ class FactoryErrorMappingComponentTest {
     }
 
     @Test
+    fun aBare404MapsToServerTooOld() = runBlocking {
+        // A server too old to route /v2 answers with a bare 404 - no contract error body
+        // (SPEC section 5, rollout guard); a real /v2 404 always carries one (the tests above).
+        https.server.enqueue(okhttp3.mockwebserver.MockResponse().setResponseCode(404))
+
+        val result = client().getLibraryItem("nope")
+
+        assertEquals(RatatoskrError.ServerTooOld, (result as ApiResult.Failure).error)
+    }
+
+    @Test
     fun a502MapsToUpstreamWithTheParsedErrorBody() = runBlocking {
         https.enqueueJson("""{"code":"abs_unreachable","message":"Audiobookshelf down"}""", code = 502)
 

--- a/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
+++ b/core-network/src/androidTest/java/io/github/xexanos/ratatoskr/network/component/FactoryErrorMappingComponentTest.kt
@@ -13,6 +13,7 @@ import io.github.xexanos.ratatoskr.network.domain.ApiResult
 import io.github.xexanos.ratatoskr.network.domain.RatatoskrError
 import io.github.xexanos.ratatoskr.network.testutil.HttpsMockServer
 import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -64,9 +65,7 @@ class FactoryErrorMappingComponentTest {
 
     @Test
     fun aBare404MapsToServerTooOld() = runBlocking {
-        // A server too old to route /v2 answers with a bare 404 - no contract error body
-        // (SPEC section 5, rollout guard); a real /v2 404 always carries one (the tests above).
-        https.server.enqueue(okhttp3.mockwebserver.MockResponse().setResponseCode(404))
+        https.server.enqueue(MockResponse().setResponseCode(404))
 
         val result = client().getLibraryItem("nope")
 

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -173,8 +173,6 @@ class RatatoskrClient internal constructor(
         val parsed = errorBody?.let { runCatching { moshi.adapter(GenError::class.java).fromJson(it) }.getOrNull() }
         return when (status) {
             401 -> RatatoskrError.Unauthorized(parsed?.code)
-            // Every 404 a real server sends carries the contract's error body; a bare one comes
-            // from a server too old to route /v2 at all (SPEC section 5, rollout guard).
             404 -> when {
                 parsed == null -> RatatoskrError.ServerTooOld
                 sessionEndpoint -> RatatoskrError.NoActiveSession

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClient.kt
@@ -173,7 +173,13 @@ class RatatoskrClient internal constructor(
         val parsed = errorBody?.let { runCatching { moshi.adapter(GenError::class.java).fromJson(it) }.getOrNull() }
         return when (status) {
             401 -> RatatoskrError.Unauthorized(parsed?.code)
-            404 -> if (sessionEndpoint) RatatoskrError.NoActiveSession else RatatoskrError.NotFound
+            // Every 404 a real server sends carries the contract's error body; a bare one comes
+            // from a server too old to route /v2 at all (SPEC section 5, rollout guard).
+            404 -> when {
+                parsed == null -> RatatoskrError.ServerTooOld
+                sessionEndpoint -> RatatoskrError.NoActiveSession
+                else -> RatatoskrError.NotFound
+            }
             502 -> RatatoskrError.Upstream(parsed?.code, parsed?.message)
             else -> RatatoskrError.Server(status, parsed?.code, parsed?.message)
         }

--- a/core-network/src/main/java/io/github/xexanos/ratatoskr/network/domain/ApiResult.kt
+++ b/core-network/src/main/java/io/github/xexanos/ratatoskr/network/domain/ApiResult.kt
@@ -32,6 +32,13 @@ sealed interface RatatoskrError {
     /** A requested resource was not found (HTTP 404 elsewhere). */
     data object NotFound : RatatoskrError
 
+    /**
+     * A route answered 404 without the contract's error body. Every 404 a real server sends
+     * carries one, so a bare 404 means the server predates `/v2` entirely and is too old for
+     * this app (SPEC section 5, rollout guard). The UI prompts to update the server.
+     */
+    data object ServerTooOld : RatatoskrError
+
     /** The server reported a structured error. [code] is its stable machine-readable code. */
     data class Server(val httpStatus: Int, val code: String?, val message: String?) : RatatoskrError
 

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -96,6 +96,29 @@ class RatatoskrClientTest {
     }
 
     @Test
+    fun `bare 404 on a session endpoint maps to ServerTooOld`() = runBlocking {
+        // A server too old to speak /v2 answers its routes with a bare 404 - no contract error
+        // body - unlike a real /v2 404, which always carries one (SPEC section 5, rollout guard).
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val result = client.currentSession()
+
+        assertEquals(RatatoskrError.ServerTooOld, (result as ApiResult.Failure).error)
+    }
+
+    @Test
+    fun `bare 404 elsewhere maps to ServerTooOld`() = runBlocking {
+        // "Bare" includes a framework's HTML error page: anything but the contract's Error shape.
+        server.enqueue(
+            MockResponse().setResponseCode(404).setBody("<html>Cannot POST /v2/auth/login</html>"),
+        )
+
+        val result = client.login("alex", "secret")
+
+        assertEquals(RatatoskrError.ServerTooOld, (result as ApiResult.Failure).error)
+    }
+
+    @Test
     fun `401 maps to Unauthorized carrying the body code`() = runBlocking {
         server.enqueue(MockResponse().setResponseCode(401).setBody("""{"code":"unauthorized","message":"no"}"""))
 

--- a/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
+++ b/core-network/src/test/java/io/github/xexanos/ratatoskr/network/api/RatatoskrClientTest.kt
@@ -97,8 +97,6 @@ class RatatoskrClientTest {
 
     @Test
     fun `bare 404 on a session endpoint maps to ServerTooOld`() = runBlocking {
-        // A server too old to speak /v2 answers its routes with a bare 404 - no contract error
-        // body - unlike a real /v2 404, which always carries one (SPEC section 5, rollout guard).
         server.enqueue(MockResponse().setResponseCode(404))
 
         val result = client.currentSession()


### PR DESCRIPTION
Closes #122. Child of #114, stacked on `feat/migrate-v2-ratatoskr-token`.

## What

Graceful degradation when the app is newer than the server (SPEC §4/§5). A server too old to speak `/v2` answers `/v2` routes with a **bare 404** — no contract error body — while every 404 a real `/v2` server sends carries one (the contract requires `code` + `message`). That difference is the client-side discrimination:

- `RatatoskrClient.mapHttpError`: a 404 whose body does not parse as the contract's `Error` maps to the new `RatatoskrError.ServerTooOld`; structured 404s keep their existing `NoActiveSession`/`NotFound` meaning.
- `UiError`: `ServerTooOld` resolves to targeted copy — update the server to **2.0.0 or newer**, with the generic fallback of installing an earlier version of this app (no hardcoded app version), en-US + de-DE.

The prompt surfaces through the established error surfaces (sign-in error card being the main path: migration re-login → `POST /v2/auth/login` → bare 404).

## Tests

- Unit (`RatatoskrClientTest`): bare 404 on a session endpoint and elsewhere (empty and HTML bodies) → `ServerTooOld`; structured 404s unchanged.
- Component (`FactoryErrorMappingComponentTest`): bare 404 through the assembled TLS-pinned client.
- Integration (`AppFlowTest`): whole app driven through connect → trust → sign-in against a pre-/v2 server shows the update-server guidance.

All unit suites, the component class, and the full `AppFlowTest` class are green locally (emulator).

## Note on the version-bump guard

Like the sibling PRs into this feature branch (#126, #127), the version-bump guard fails by design here: the bump to 2.0.0 happens once when the feature branch merges into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)