### PR TITLE
docs(changelog): document the conventions and move the release guards into scripts

### DIFF
--- a/.github/workflows/pr-release-guards.yml
+++ b/.github/workflows/pr-release-guards.yml
@@ -21,6 +21,12 @@
 # version-bump guard simply finds no release-worthy commits and passes, and store-metadata checks
 # the entries whatever the PR is about (a changelog is just as easy to break in a docs PR).
 #
+# The two guards' logic lives in scripts/ (check-version-bump.py, check-store-metadata.py)
+# rather than inline here, so both can be run locally before pushing:
+#
+#   python3 scripts/check-version-bump.py origin/main HEAD
+#   python3 scripts/check-store-metadata.py
+#
 # Concurrent-PR caveat: the guard compares against the PR's base. Two PRs branched off the same
 # commit can both bump to the same version and both pass; whichever merges second then re-points no
 # new tag. Enable branch protection's "require branches to be up to date before merging" so the
@@ -70,72 +76,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-
-          # --- classify the PR's commits (identical rules to the server's promote.yml) ----------
-          # Only feat/fix/perf/breaking force a bump. `revert` is deliberately release-neutral here
-          # (matching the server's classifier), so reverting a shipped feat/fix does not by itself
-          # require a bump - rare, and kept consistent across the two pipelines on purpose.
-          subjects="$(git log --format='%s' "${BASE_SHA}..${HEAD_SHA}")"
-          bodies="$(git log --format='%b' "${BASE_SHA}..${HEAD_SHA}")"
-          bump="none"
-          if grep -qE '^[a-z]+(\([^)]*\))?!:' <<< "$subjects" \
-             || grep -qE '^BREAKING[ -]CHANGE:' <<< "$bodies"; then
-            bump="major"
-          elif grep -qE '^feat(\([^)]*\))?:' <<< "$subjects"; then
-            bump="minor"
-          elif grep -qE '^(fix|perf)(\([^)]*\))?:' <<< "$subjects"; then
-            bump="patch"
-          fi
-
-          if [ "$bump" = "none" ]; then
-            echo "No release-worthy commits (feat/fix/perf/breaking) in this PR - a version bump is not required."
-            exit 0
-          fi
-
-          fail() { echo "::error::$*"; exit 1; }
-
-          # --- read versionName/versionCode at base and head ------------------------------------
-          # The trailing grep exits 1 when nothing matches; the `|| true` keeps that from aborting
-          # the whole script inside the command substitution (set -euo pipefail) BEFORE the
-          # empty-checks below can turn it into a clear message.
-          read_vn() { git show "$1:app/build.gradle.kts" 2>/dev/null | grep -E '^\s*versionName\s*=' | head -n1 | grep -oP 'versionName\s*=\s*"\K[^"]+' || true; }
-          read_vc() { git show "$1:app/build.gradle.kts" 2>/dev/null | grep -E '^\s*versionCode\s*='  | head -n1 | grep -oP 'versionCode\s*=\s*\K[0-9]+' || true; }
-          base_vn="$(read_vn "$BASE_SHA")"; base_vc="$(read_vc "$BASE_SHA")"
-          head_vn="$(read_vn "$HEAD_SHA")"; head_vc="$(read_vc "$HEAD_SHA")"
-          [ -n "$head_vn" ] && [ -n "$head_vc" ] || fail "Could not read versionName/versionCode from app/build.gradle.kts at head (${HEAD_SHA})."
-          [ -n "$base_vn" ] && [ -n "$base_vc" ] || fail "Could not read versionName/versionCode from app/build.gradle.kts at base (${BASE_SHA})."
-
-          case "$head_vn" in
-            [0-9]*.[0-9]*.[0-9]*) : ;;
-            *) fail "versionName '${head_vn}' is not MAJOR.MINOR.PATCH (SPEC section 8)." ;;
-          esac
-
-          # --- versionCode must equal the SPEC formula MAJOR*10000 + MINOR*100 + PATCH -----------
-          formula() { local M m p; IFS=. read -r M m p <<< "$1"; echo $(( M*10000 + m*100 + p )); }
-          want_vc="$(formula "$head_vn")"
-          [ "$head_vc" = "$want_vc" ] || fail "versionCode ${head_vc} does not match versionName ${head_vn} (expected ${want_vc} = MAJOR*10000+MINOR*100+PATCH, SPEC section 8)."
-
-          # --- the bump must be at least the level the commits imply ----------------------------
-          IFS=. read -r M m p <<< "$base_vn"
-          case "$bump" in
-            major) M=$((M+1)); m=0; p=0 ;;
-            minor) m=$((m+1)); p=0 ;;
-            patch) p=$((p+1)) ;;
-          esac
-          expected_vn="${M}.${m}.${p}"
-          # true when $1 >= $2 as versions
-          ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]; }
-          if ! ge "$head_vn" "$expected_vn"; then
-            fail "This PR has ${bump}-level commits but versionName is still ${head_vn} (base ${base_vn}). Bump to at least ${expected_vn} (versionCode $(formula "$expected_vn")) in app/build.gradle.kts, and add fastlane/metadata/android/en-US/changelogs/$(formula "$expected_vn").txt."
-          fi
-
-          # --- the fastlane changelog for the new versionCode must exist and be non-empty --------
-          changelog="fastlane/metadata/android/en-US/changelogs/${head_vc}.txt"
-          [ -s "$changelog" ] || fail "Missing (or empty) changelog ${changelog} for versionCode ${head_vc} (SPEC section 8 requires at least en-US)."
-
-          echo "OK: ${bump}-level PR bumps ${base_vn} (${base_vc}) -> ${head_vn} (${head_vc}); changelog present."
+        run: python3 scripts/check-version-bump.py
 
   store-metadata:
     name: Store metadata conventions

--- a/.github/workflows/pr-release-guards.yml
+++ b/.github/workflows/pr-release-guards.yml
@@ -1,5 +1,5 @@
-# Per-PR release guards. Two independent checks that keep the continuous-versioning release model
-# (SPEC section 8) honest, so a release-worthy change can never merge without the version bump the
+# Per-PR release guards. Three independent checks that keep the release model (SPEC section 8)
+# honest, so a release-worthy change can never merge without the version bump the
 # automated tag gate (promote.yml) needs - "forgetting to bump" is caught here, loudly, instead of
 # silently producing no release later (promote.yml no-ops when the versionName is already tagged).
 #
@@ -10,10 +10,16 @@
 #                     bump versionName/versionCode in app/build.gradle.kts by at least the semver
 #                     level those commits imply, keep versionCode consistent with the SPEC formula,
 #                     and ship the matching fastlane changelog. Otherwise no bump is required.
+#   - store-metadata: the changelog entries themselves hold to the store's shape - the
+#                     500-CHARACTER limit, one paragraph on one line, and en-US/de-DE as a
+#                     pair. The version-bump guard only asserts that the new en-US file
+#                     exists and is non-empty, which is how the German 10800 entry went
+#                     missing (#142). Rules in fastlane/metadata/README.md.
 #
-# Deliberately its own workflow (no paths-ignore): both jobs must ALWAYS report so they are safe to
-# make required status checks. A docs-only PR still runs them - commitlint always applies, and the
-# version-bump guard simply finds no release-worthy commits and passes.
+# Deliberately its own workflow (no paths-ignore): all three jobs must ALWAYS report so they are safe
+# to make required status checks. A docs-only PR still runs them - commitlint always applies, the
+# version-bump guard simply finds no release-worthy commits and passes, and store-metadata checks
+# the entries whatever the PR is about (a changelog is just as easy to break in a docs PR).
 #
 # Concurrent-PR caveat: the guard compares against the PR's base. Two PRs branched off the same
 # commit can both bump to the same version and both pass; whichever merges second then re-points no
@@ -130,3 +136,11 @@ jobs:
           [ -s "$changelog" ] || fail "Missing (or empty) changelog ${changelog} for versionCode ${head_vc} (SPEC section 8 requires at least en-US)."
 
           echo "OK: ${bump}-level PR bumps ${base_vn} (${base_vc}) -> ${head_vn} (${head_vc}); changelog present."
+
+  store-metadata:
+    name: Store metadata conventions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check the fastlane changelog conventions
+        run: python3 scripts/check-store-metadata.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Working agreements:
 - The technology stack (SPEC section 12) and the screen and module structure (SPEC
   section 13) are decided and recorded in the SPEC; changes to them go through the SPEC
   first.
+- Store listing text, and release changelogs in particular, follow
+  `fastlane/metadata/README.md` (500-character limit, one line, both locales).
 
 ## Agent skills
 

--- a/fastlane/metadata/README.md
+++ b/fastlane/metadata/README.md
@@ -1,0 +1,60 @@
+# Store metadata
+
+F-Droid builds the store listing from `android/<locale>/`: title, descriptions, images and
+the per-release changelogs. `docs/SPEC.md` (section 12) covers what belongs here, how the
+changelog files are named after the `versionCode`, and what CI enforces. This file covers how
+to *write* an entry, which the files alone do not reveal.
+
+## Changelogs
+
+One file per released version code: `android/<locale>/changelogs/<versionCode>.txt`.
+
+### Form
+
+- **500 characters is a hard ceiling**, counting the trailing newline. It is a store limit,
+  not a preference - a longer entry gets truncated. Aim for 480 or less, so a later wording
+  fix still has room. It is 500 *characters*, not bytes: German text spends extra bytes on
+  umlauts, so byte-based tools (`wc -c`, or `wc -m` in the C locale) overcount.
+- **One paragraph on one line.** No headings, no lists, no blank lines, no hard wrapping.
+- **UTF-8 without BOM, LF, exactly one trailing newline.** `.gitattributes` normalises the
+  line ending; the rest is on you.
+- **`en-US` and `de-DE` come as a pair.** `pr-release-guards.yml` only checks that `en-US`
+  exists and is non-empty, so nothing catches a missing translation. Write both in the same
+  commit.
+
+### Voice
+
+- **Second person, about what the reader gets.** An entry describes the visible outcome, not
+  the implementation: "session state is now tracked in one place" is a commit message, "the
+  shelf refreshes the moment a book stops playing" is a changelog.
+- **No jargon and no internal names.** Class names, module names and issue numbers stay out.
+- **Only promise what the app really does.** The entry is public and outlives the release, so
+  it must not outrun what the SPEC guarantees, and it must not advertise anything a later
+  change might walk back.
+- **A plain hyphen `-` for an aside**, never an en dash (U+2013) or em dash (U+2014).
+- **Quotes follow the locale**: German uses „...“ (U+201E and U+201C), English plain
+  straight `"`.
+- **Name things the way the UI does.** Take screen and feature wording from
+  `app/src/main/res/values/strings.xml` and `values-de/strings.xml` (Weiterhören,
+  Lautsprecher, Wiedergabe-Bildschirm) rather than inventing a term the reader cannot find in
+  the app.
+
+The quickest way to match the tone is to read the two or three preceding entries in the same
+locale before writing.
+
+### Checking an entry
+
+Byte-counting tools misreport the length, so check with Python:
+
+```bash
+python - <<'PY'
+import glob, io
+NL = chr(10)
+for p in sorted(glob.glob("fastlane/metadata/android/*/changelogs/*.txt")):
+    s = io.open(p, encoding="utf-8").read()
+    if len(s) > 500 or s.count(NL) != 1 or not s.endswith(NL):
+        print("%s: %d characters, %d lines" % (p, len(s), s.count(NL)))
+PY
+```
+
+Silence means every entry is within the limit, on a single line, and newline-terminated.

--- a/fastlane/metadata/README.md
+++ b/fastlane/metadata/README.md
@@ -18,9 +18,8 @@ One file per released version code: `android/<locale>/changelogs/<versionCode>.t
 - **One paragraph on one line.** No headings, no lists, no blank lines, no hard wrapping.
 - **UTF-8 without BOM, LF, exactly one trailing newline.** `.gitattributes` normalises the
   line ending; the rest is on you.
-- **`en-US` and `de-DE` come as a pair.** `pr-release-guards.yml` only checks that `en-US`
-  exists and is non-empty, so nothing catches a missing translation. Write both in the same
-  commit.
+- **`en-US` and `de-DE` come as a pair.** Write both in the same commit; the check below
+  rejects a version code that exists in only one of them.
 
 ### Voice
 
@@ -44,17 +43,13 @@ locale before writing.
 
 ### Checking an entry
 
-Byte-counting tools misreport the length, so check with Python:
-
 ```bash
-python - <<'PY'
-import glob, io
-NL = chr(10)
-for p in sorted(glob.glob("fastlane/metadata/android/*/changelogs/*.txt")):
-    s = io.open(p, encoding="utf-8").read()
-    if len(s) > 500 or s.count(NL) != 1 or not s.endswith(NL):
-        print("%s: %d characters, %d lines" % (p, len(s), s.count(NL)))
-PY
+python3 scripts/check-store-metadata.py
 ```
 
-Silence means every entry is within the limit, on a single line, and newline-terminated.
+It enforces the mechanical rules above over every entry - the character limit, the single
+line, the trailing newline, LF, and the locale pairing - and reports the paths that break
+them. CI runs the same script as the "Store metadata conventions" job of
+`pr-release-guards.yml`, so a broken entry fails the PR rather than reaching the store.
+
+Voice is deliberately not checked. Read the neighbouring entries instead.

--- a/scripts/check-store-metadata.py
+++ b/scripts/check-store-metadata.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+#
+# F-Droid store metadata guardrails - the mechanical half of the conventions in
+# fastlane/metadata/README.md. Run locally with `python3 scripts/check-store-metadata.py`;
+# CI runs it from .github/workflows/pr-release-guards.yml.
+#
+# Checks only what a machine can decide. Tone, voice and wording stay a review matter.
+#
+# Why Python and not the shell: the 500 limit is 500 CHARACTERS, and byte-counting tools
+# disagree with that on German entries - `wc -c`, and `wc -m` outside a UTF-8 locale, report
+# 509 for the 499-character de-DE/10802. A byte-based gate would reject a valid entry.
+
+import glob
+import os
+import sys
+
+ROOT = "fastlane/metadata/android"
+LIMIT = 500
+NL = chr(10)
+CR = chr(13)
+
+# The locales kept in sync as a pair. F-Droid falls back to en-US for anything missing, so a
+# further locale can be added here once it is actually maintained - until then a stray
+# third-locale file is left alone rather than dragging the other locales along with it.
+PAIRED_LOCALES = ("en-US", "de-DE")
+
+
+def changelog_paths(locale):
+    pattern = os.path.join(ROOT, locale, "changelogs", "*.txt")
+    return sorted(p.replace(os.sep, "/") for p in glob.glob(pattern))
+
+
+def check_file(path, problems):
+    # newline="" keeps universal-newline mode from rewriting CRLF to LF, which would
+    # make the CR check below unable to fire.
+    with open(path, encoding="utf-8", newline="") as handle:
+        text = handle.read()
+
+    if not text.strip():
+        problems.append("%s: empty" % path)
+        return
+
+    if len(text) > LIMIT:
+        problems.append(
+            "%s: %d characters, over the %d-character store limit"
+            % (path, len(text), LIMIT)
+        )
+
+    if CR in text:
+        problems.append("%s: contains CR; store metadata is LF-only" % path)
+
+    if not text.endswith(NL):
+        problems.append("%s: missing the trailing newline" % path)
+    elif text.count(NL) != 1:
+        problems.append(
+            "%s: %d lines; an entry is one paragraph on one line"
+            % (path, text.count(NL))
+        )
+
+
+def check_pairing(problems):
+    codes = {}
+    for locale in PAIRED_LOCALES:
+        codes[locale] = set(
+            os.path.basename(p) for p in changelog_paths(locale)
+        )
+
+    for locale in PAIRED_LOCALES:
+        for other in PAIRED_LOCALES:
+            if locale == other:
+                continue
+            for name in sorted(codes[locale] - codes[other]):
+                problems.append(
+                    "%s/%s/changelogs/%s has no %s translation"
+                    % (ROOT, locale, name, other)
+                )
+
+
+def main():
+    problems = []
+
+    checked = 0
+    for locale in PAIRED_LOCALES:
+        for path in changelog_paths(locale):
+            check_file(path, problems)
+            checked += 1
+
+    if checked == 0:
+        problems.append("no changelog files found under %s - wrong directory?" % ROOT)
+
+    check_pairing(problems)
+
+    if problems:
+        annotate = os.environ.get("GITHUB_ACTIONS") == "true"
+        for problem in problems:
+            print(("::error::" if annotate else "  FAIL: ") + problem)
+        print()
+        print(
+            "Store metadata guardrails failed. See fastlane/metadata/README.md for the "
+            "conventions these enforce."
+        )
+        return 1
+
+    print("Store metadata guardrails passed (%d changelog entries)." % checked)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-version-bump.py
+++ b/scripts/check-version-bump.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+#
+# Release guard: a PR carrying release-worthy commits must bump versionName/versionCode
+# (SPEC section 8) and ship the matching en-US changelog, so the automated tag gate
+# (promote.yml) has a fresh version to cut. CI runs it from
+# .github/workflows/pr-release-guards.yml; run it locally against any two refs with
+#
+#   python3 scripts/check-version-bump.py origin/main HEAD
+#
+# The commit classification is deliberately identical to the server's promote.yml:
+# only feat/fix/perf/breaking force a bump, and `revert` is release-neutral.
+
+import os
+import re
+import subprocess
+import sys
+
+GRADLE = "app/build.gradle.kts"
+CHANGELOG = "fastlane/metadata/android/en-US/changelogs/{code}.txt"
+
+BREAKING_SUBJECT = re.compile(r"^[a-z]+(\([^)]*\))?!:")
+BREAKING_BODY = re.compile(r"^BREAKING[ -]CHANGE:", re.MULTILINE)
+FEAT = re.compile(r"^feat(\([^)]*\))?:")
+FIX_OR_PERF = re.compile(r"^(fix|perf)(\([^)]*\))?:")
+SEMVER = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def fail(message):
+    prefix = "::error::" if os.environ.get("GITHUB_ACTIONS") == "true" else "FAIL: "
+    print(prefix + message)
+    sys.exit(1)
+
+
+def git(*args):
+    result = subprocess.run(
+        ["git"] + list(args),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def classify(base, head):
+    """The semver level the PR's commits imply: major, minor, patch or none.
+
+    `revert` is deliberately release-neutral, matching the server's classifier, so
+    reverting a shipped feat/fix does not by itself require a bump - rare, and kept
+    consistent across the two pipelines on purpose.
+    """
+    subjects = git("log", "--format=%s", base + ".." + head)
+    bodies = git("log", "--format=%b", base + ".." + head)
+
+    if any(BREAKING_SUBJECT.match(line) for line in subjects.splitlines()):
+        return "major"
+    if BREAKING_BODY.search(bodies):
+        return "major"
+    if any(FEAT.match(line) for line in subjects.splitlines()):
+        return "minor"
+    if any(FIX_OR_PERF.match(line) for line in subjects.splitlines()):
+        return "patch"
+    return "none"
+
+
+def read_version(rev):
+    """versionName/versionCode as declared at `rev`, or (None, None) when unreadable."""
+    source = git("show", rev + ":" + GRADLE)
+    name = code = None
+    for line in source.splitlines():
+        if name is None and re.match(r"^\s*versionName\s*=", line):
+            found = re.search(r'versionName\s*=\s*"([^"]+)"', line)
+            name = found.group(1) if found else None
+        if code is None and re.match(r"^\s*versionCode\s*=", line):
+            found = re.search(r"versionCode\s*=\s*(\d+)", line)
+            code = int(found.group(1)) if found else None
+    return name, code
+
+
+def formula(name):
+    """versionCode derived from versionName, per SPEC section 8."""
+    major, minor, patch = (int(part) for part in name.split("."))
+    return major * 10000 + minor * 100 + patch
+
+
+def raise_to(name, level):
+    major, minor, patch = (int(part) for part in name.split("."))
+    if level == "major":
+        return "%d.0.0" % (major + 1)
+    if level == "minor":
+        return "%d.%d.0" % (major, minor + 1)
+    return "%d.%d.%d" % (major, minor, patch + 1)
+
+
+def main(argv):
+    if len(argv) == 3:
+        base, head = argv[1], argv[2]
+    else:
+        base = os.environ.get("BASE_SHA", "")
+        head = os.environ.get("HEAD_SHA", "")
+        if not base or not head:
+            print("usage: check-version-bump.py <base-ref> <head-ref>")
+            print("       (or set BASE_SHA and HEAD_SHA)")
+            return 2
+
+    bump = classify(base, head)
+    if bump == "none":
+        print(
+            "No release-worthy commits (feat/fix/perf/breaking) in this PR - "
+            "a version bump is not required."
+        )
+        return 0
+
+    head_vn, head_vc = read_version(head)
+    base_vn, base_vc = read_version(base)
+    if head_vn is None or head_vc is None:
+        fail("Could not read versionName/versionCode from %s at head (%s)." % (GRADLE, head))
+    if base_vn is None or base_vc is None:
+        fail("Could not read versionName/versionCode from %s at base (%s)." % (GRADLE, base))
+
+    for label, name in (("head", head_vn), ("base", base_vn)):
+        if not SEMVER.match(name):
+            fail(
+                "versionName '%s' at %s is not MAJOR.MINOR.PATCH (SPEC section 8)."
+                % (name, label)
+            )
+
+    want_vc = formula(head_vn)
+    if head_vc != want_vc:
+        fail(
+            "versionCode %d does not match versionName %s (expected %d = "
+            "MAJOR*10000+MINOR*100+PATCH, SPEC section 8)." % (head_vc, head_vn, want_vc)
+        )
+
+    expected_vn = raise_to(base_vn, bump)
+    as_tuple = lambda name: tuple(int(part) for part in name.split("."))
+    if as_tuple(head_vn) < as_tuple(expected_vn):
+        fail(
+            "This PR has %s-level commits but versionName is still %s (base %s). Bump to at "
+            "least %s (versionCode %d) in %s, and add %s."
+            % (
+                bump, head_vn, base_vn, expected_vn, formula(expected_vn), GRADLE,
+                CHANGELOG.format(code=formula(expected_vn)),
+            )
+        )
+
+    changelog = CHANGELOG.format(code=head_vc)
+    if not os.path.isfile(changelog) or os.path.getsize(changelog) == 0:
+        fail(
+            "Missing (or empty) changelog %s for versionCode %d (SPEC section 8 requires at "
+            "least en-US)." % (changelog, head_vc)
+        )
+
+    print(
+        "OK: %s-level PR bumps %s (%d) -> %s (%d); changelog present."
+        % (bump, base_vn, base_vc, head_vn, head_vc)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Follow-up to #142, in three commits.

**1. Document the conventions** in `fastlane/metadata/README.md`, with a pointer from
`CLAUDE.md`. Writing the German 10800 entry meant deriving them from the existing
files, because none were written down: the 500-character store limit, one paragraph on
one line, second person, plain hyphens, the per-locale quote style, and that `en-US`
and `de-DE` come as a pair. It does not restate what SPEC section 12 already covers
(file naming, the `versionCode` formula, the bump guard) - it links there instead.

**2. Enforce the mechanical half** in `scripts/check-store-metadata.py`, run as a third
job of `pr-release-guards.yml`. Documenting a limit does not stop anyone exceeding it,
and the existing guard only asserts that the new `en-US` file exists and is non-empty -
exactly how the German 10800 entry went missing. Covers the character limit, the single
line, the trailing newline, LF, and locale pairing, over every entry. Voice is left to
review.

**3. Move the version-bump guard into `scripts/check-version-bump.py`** so the pipeline
does not mix 66 lines of inline bash with a Python script. The workflow step is now one
line, and both guards run locally:

```
python3 scripts/check-version-bump.py origin/main HEAD
python3 scripts/check-store-metadata.py
```

Local runs were impossible for the bash version: it used `grep -oP`, which Git Bash on
Windows refuses outside a UTF-8 locale, so the guard could only be exercised by pushing.

### Verification

The store metadata check was verified by breaking each rule in turn (over-limit, CR,
missing trailing newline, two lines, empty file, deleted translation): each fails with
exit 1, and the current tree passes.

The version-bump rewrite was compared against the bash it replaces across 17 scenarios -
each bump level, scoped and breaking subjects, `BREAKING CHANGE` bodies, missing and
empty changelogs, versionCode mismatch, insufficient and oversized bumps, release-neutral
`revert`. All 17 agree. Note that CI on this PR only exercises the early-exit path, since
these commits are not release-worthy; the rest rests on that local comparison.

One deliberate behaviour change: `versionName` is now validated as MAJOR.MINOR.PATCH at
base as well as head. The old glob accepted a malformed base version and computed a
nonsense expected version from it, and a malformed head version such as `1.9.0-rc1` got
as far as crashing the script on `rc1: unbound variable` rather than reporting anything
useful.

### Not included

- **"Store metadata conventions" is not a required check yet.** The workflow has no
  `paths-ignore` and always reports, so it is safe to require, but the ruleset lists
  contexts by name and would need it added.
- `scripts/check-ux.sh` stays bash. It has no inline-vs-script split to fix.

Docs and CI only, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
