### PR TITLE
test(compose): migrate the UI tests to the junit4 v2 compose rules

### DIFF
--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AccessibilityChecksTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AccessibilityChecksTest.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onRoot

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/AppFlowTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasImeAction
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/CoverImageTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/CoverImageTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/MigrationFlowTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/MigrationFlowTest.kt
@@ -8,7 +8,7 @@ package io.github.xexanos.ratatoskr.ui
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasImeAction
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput

--- a/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/StoreScreenshotsTest.kt
+++ b/app/src/androidTest/java/io/github/xexanos/ratatoskr/ui/StoreScreenshotsTest.kt
@@ -9,7 +9,7 @@ import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import androidx.compose.ui.test.hasImeAction
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick


### PR DESCRIPTION
## What

Compose BOM 2026.08.00 deprecates `createComposeRule` / `createAndroidComposeRule` in `androidx.compose.ui.test.junit4` in favour of `androidx.compose.ui.test.junit4.v2.*`. Every Compose UI test in the repo used the old API, so each build emitted five deprecation warnings. This switches all five to the v2 package. The build is now warning-free.

## Why it stayed a one-line-per-file change

The v2 factories return the *same* `ComposeContentTestRule` / `AndroidComposeTestRule` types — I checked the bytecode rather than assuming. The only behavioural difference is that v2 passes `useStandardTestDispatcherForComposition = true` into `AndroidComposeUiTestEnvironment`, so composition work is queued on a `StandardTestDispatcher` instead of running eagerly on an `UnconfinedTestDispatcher`. That is what the deprecation message warns about ("tests relying on immediate execution may require explicit synchronization").

No test in this repo relied on eager execution, so none needed extra synchronisation:

- Every assertion is reached either through the semantics API (`onNode*`, which does an implicit idle wait) or through `ComposeSync`'s `waitUntil` polling. Both drive the composition dispatcher, so the queued work runs before anything is asserted.
- `ComposeSync.kt` needed no change. It was already written against the semantics-polling model — which is exactly what the queuing dispatcher requires — and its KDoc is still accurate under v2. Verified empirically, not by inspection: it is the synchronisation path for all 12 whole-app flow tests, which pass unchanged.
- `AccessibilityChecksTest.runChecksAfterLoaderDelay` was the one genuine risk, since it sets `mainClock.autoAdvance = false` *before* `setContent`. Under v2 `mainClock.advanceTimeBy` still drains the queued composition, and the helper's own "the delayed knot loader never appeared" assert proves this isn't a vacuous pass.

## Verification

Migrated and ran one file at a time on the `Medium_Phone` AVD (android-36):

| Test | Result |
| --- | --- |
| `CoverImageTest` | 4/4 |
| `AccessibilityChecksTest` | 27/27 |
| `MigrationFlowTest` | 1/1 |
| `AppFlowTest` | 10/10 |
| `StoreScreenshotsTest` | 1/1 with `captureScreenshots=true` |

`StoreScreenshotsTest` self-skips by default, so verifying it needed the capture flag; I pulled the captured PNGs off the device and confirmed they are real rendered screens rather than blank or half-composed frames — the failure mode a dispatcher problem would produce.

Also green: `lintDebug`, `verifyRoborazziDebug` (goldens unchanged, as expected for a test-only change), `-PminifiedTests :app:assembleMinifiedAndroidTest`, and the release-validation path `-PminifiedTests :app:connectedMinifiedAndroidTest` over `AppFlowTest` + `MinifiedWireSmokeTest` at 13/13 under R8.

## Note

The task listed `app/src/test/java/io/github/xexanos/ratatoskr/ui/InlineBannerTest.kt` as a sixth affected file. It does not exist on `main`, and `app/src/test` contains no Compose UI tests at all — the JVM tree's only Compose rendering goes through Roborazzi's generated preview tests, which use their own rule and are untouched by this deprecation. The five files here are exactly the five the compiler flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
