### PR TITLE
test(compose): move the last test onto the junit4 v2 rule

### DIFF
--- a/app/src/test/java/io/github/xexanos/ratatoskr/ui/InlineBannerTest.kt
+++ b/app/src/test/java/io/github/xexanos/ratatoskr/ui/InlineBannerTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.github.xexanos.ratatoskr.ui.theme.RatatoskrTheme


### PR DESCRIPTION
Closes the gap left between #146 and #149.

#149 migrated the five UI tests it could see. `InlineBannerTest` was not among them — it arrived with #146, which merged afterwards, so it simply did not exist in that branch's tree. `main` ended up with five files on `junit4.v2` and one on the deprecated rule, which is the worst shape for a migration to be in: the build kept emitting the deprecation warning while the change history read as finished.

That is my fault rather than #149's. I wrote the task prompt for that migration against the state of my own unmerged branch, listing `InlineBannerTest.kt` as one of six affected files while it existed only on `feat/error-roles-and-inline-banner`. The session did exactly what it could see.

One import. Verified rather than assumed:

- All three cases pass under v2 (`tests="3" failures="0" errors="0"`). No synchronisation was needed despite v2's `StandardTestDispatcher` — every case asserts through the semantics tree, which syncs on its own.
- `grep -rn "junit4\.create" app/src | grep -v junit4\.v2\.` now returns nothing.
- `:app:compileDebugUnitTestKotlin` emits zero `is deprecated` lines.

No version bump: no release-worthy commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
