### PR TITLE
docs: describe the JVM Compose behaviour tests in the test layers

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -347,10 +347,34 @@ across the assembled user flow. Any overlap between them is deliberately thin.
 
 ### 1. Unit tests (JVM)
 
-Pure logic with the platform pieces faked. JVM (`testDebugUnitTest`), no device, fast; most
-tests live here. In place: the auth/token logic (bearer attachment, 401 handling by `code`,
-secure-storage read/write with the platform faked) and the mapping between generated contract
-types and the domain/UI models (including unknown-field tolerance).
+JVM (`testDebugUnitTest`), no device, fast; most tests live here. Two kinds share the layer.
+
+Pure logic with the platform pieces faked is the bulk of it: the auth/token logic (bearer
+attachment, 401 handling by `code`, secure-storage read/write with the platform faked), the
+mapping between generated contract types and the domain/UI models (including unknown-field
+tolerance), and the per-screen ViewModel state transitions.
+
+Non-visual Compose behaviour is the rest. A Robolectric-backed compose rule renders one
+stateless `XScreen(state, ...)` or shared component (section 13) from a hand-made UI state and
+asserts against the semantics tree — `InlineBannerTest` and the per-screen `*ScreenTest`s
+(`SignInScreenTest`). It runs on the same JVM/Robolectric renderer as the screenshot goldens,
+asked a different question: a golden pins what a frame *looks* like, these pin what it *does*.
+
+They exist because nothing else in the suite can see this. A live region is invisible to a
+golden and — being behaviour rather than a structural violation — invisible to the instrumented
+Accessibility Test Framework checks too, which cannot run here at all: they need a live
+accessibility service and silently pass on Robolectric. A golden also freezes one frame, so it
+says nothing about *which* frame a screen chooses: whether the trust chip is there at all,
+whether the visibility toggle swaps a masked password for a revealed one, whether the banner
+surface itself is the retry target rather than a nested label. That is what belongs here —
+semantics that are behaviour rather than structure, and the choice between states.
+
+This is deliberately not a small copy of layer 3. One composable is driven directly with a
+state handed to it: no navigation graph, no ViewModel, no `ConnectionManager`, no
+`MockWebServer`, so nothing about the assembled flow is under test — "integration test" here
+means layer 3's whole app through its UI, and nothing else. Behaviour that needs the app wired
+together belongs there; conformance that needs a real accessibility node tree belongs
+instrumented.
 
 ### 2. Component tests (instrumented)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,10 +23,25 @@ server + ABS + Sonos together are **E2E** and live in the central repo, not here
 - single-flight token refresh logic
 - TLS fingerprint comparison / trust-on-first-use decision
 - per-screen ViewModel state transitions
+- non-visual Compose behaviour of one stateless screen or shared component:
+  live regions, which frame a screen chooses, semantics that are behaviour
+  rather than structure
+- screenshot goldens for every UI `@Preview` (Roborazzi, `verifyRoborazziDebug`)
 
 Runner: **JUnit4** (chosen for one framework across all levels — the instrumented
 layers below are JUnit4-bound anyway). Networking-adjacent units use OkHttp
-**MockWebServer**.
+**MockWebServer**. The two Compose-rendering kinds need a real Compose runtime
+rather than a fake, so they add **Robolectric**: the behaviour tests drive one
+`XScreen(state, ...)` from a hand-made state through the junit4 v2 compose rule
+and assert on the semantics tree, the goldens render the same way and compare
+pixels. Same renderer, different question — what a frame *does* versus what it
+looks like.
+
+Neither is a small whole-app suite: no navigation, no ViewModel, no mock server.
+An **integration test** here always means the whole app driven through its UI
+(below). Nor do they replace the instrumented accessibility checks, which need a
+live accessibility service and silently pass on Robolectric. Full rationale and
+the boundary between the layers: SPEC section 9, layer 1.
 
 ### Component — instrumented on emulator, real TLS + Keystore
 `core-network` against MockWebServer over HTTPS with a held certificate. This is
@@ -68,6 +83,7 @@ black-box. See the central concept's open points.
 
 ```sh
 ./gradlew testDebugUnitTest         # unit (JVM), all modules
+./gradlew verifyRoborazziDebug      # the same JVM run, with the goldens in verify mode
 ./gradlew connectedDebugAndroidTest # component + integration + a11y on an emulator;
                                     # run from the root, it covers :core-network and :app
 ./gradlew -PminifiedTests :app:connectedMinifiedAndroidTest \
@@ -82,7 +98,9 @@ The strategy above is the target. Current state:
 - **Present:** `core-network` unit tests (JUnit4 + MockWebServer), including the
   TLS fingerprint/TOFU decision logic (`Fingerprints`, `PinnedTrustManager`);
   per-screen ViewModel state-transition unit tests (`:app`, JUnit4, against a real
-  `ConnectionStore`/DataStore on the JVM and `HttpsMockServer`); instrumented
+  `ConnectionStore`/DataStore on the JVM and `HttpsMockServer`); JVM Compose behaviour
+  tests for the shared banner and the sign-in screen (`InlineBannerTest`,
+  `SignInScreenTest`) and the Roborazzi preview goldens, both on Robolectric; instrumented
   component tests (auth, deserialization, error mapping, session rotation, TLS
   pinning); the whole-app Compose integration flow (`AppFlowTest`); accessibility
   checks across every screen (ATF, WARNING threshold incl. contrast) in **both**


### PR DESCRIPTION
🤖 *This PR was written by an AI agent.*

Spotted while reviewing #159 and left out of its scope as pre-existing. `docs/SPEC.md` §9 layer 1 and `docs/testing.md` describe the JVM level as pure logic with the platform pieces faked — mappers, auth/token handling, ViewModel state transitions. Two other kinds of test have been living there for a while and neither is described: the hand-written Compose behaviour tests on Robolectric (`InlineBannerTest`, `SignInScreenTest`, and the two `*ScreenTest`s #159 adds), and the generated Roborazzi preview goldens, which are also Robolectric tests inside `testDebugUnitTest`.

Both are now in the layer, together with the boundary that makes them worth having rather than redundant — the same "what can this layer honestly verify" framing §9 already opens with:

- a golden pins what a frame *looks* like; a behaviour test pins what it *does*. Same JVM/Robolectric renderer, different question.
- a live region is invisible to a golden, and — being behaviour rather than a structural violation — invisible to the instrumented Accessibility Test Framework checks too, which cannot run at this level at all (they need a live accessibility service and silently pass on Robolectric, as `AccessibilityChecksTest` already documents).
- a golden freezes one frame, so it says nothing about *which* frame a screen chooses: the trust chip being present at all, the visibility toggle swapping masked for revealed, the banner surface itself being the retry target.
- the layer is fenced off from the whole-app UI suite in both directions. One composable driven directly with a hand-made state has no navigation, no ViewModel, no `ConnectionManager` and no `MockWebServer`, so nothing about the assembled flow is under test — and per this repo's vocabulary, **"integration test" means only layer 3's complete app driven through its UI**. These are not that.

## Scope

Per CLAUDE.md, SPEC changes are decided in the SPEC first — so this is a correction to a stale description, not a new policy. The four layers, their numbering and every heading are unchanged; no test moved, none was added, and no decision is being introduced. §9 layer 1 also gains the ViewModel state transitions it never listed (`docs/testing.md` already had them).

`docs/testing.md` needed the addition rather than only a pointer: its `## Levels` list is an inventory of what runs at each level, and that inventory is precisely what was stale. It keeps its summary shape — two bullets and a short paragraph — and points at SPEC §9 layer 1 for the rationale, so the two documents state the same boundary without duplicating the reasoning. `## Status / alignment` and the `## Running` block are brought along, since they enumerate what is present and how to run it.

## One correction to the premise

`KnotLoaderTest` was named among the JVM Compose tests in the review note, but it is not one: no `RobolectricTestRunner`, no compose rule — it tests `wrappedRanges` and `reducedMotionFromScale` as pure functions and already fits the existing description. It is not mentioned in the docs change.

## Naming

The SPEC names `InlineBannerTest` and the `*ScreenTest` pattern with `SignInScreenTest` as its example, rather than enumerating all five files. That keeps it true whichever of this PR and #159 merges first, and #159's `NowPlayingScreenTest` / `LibraryScreenTest` then need no further doc change.

## Checks

Docs only, so no version bump: `check-version-bump.py origin/main HEAD` reports no release-worthy commits. `check-store-metadata.py` and `scripts/check-ux.sh` pass. No code touched, so no test run applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
